### PR TITLE
ci: bump checkout/setup-python to v6 (Node 24)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.8'
       - name: Verify python3.8 binary on PATH


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout@v4` → `@v6` and `actions/setup-python@v5` → `@v6` in `.github/workflows/test.yml`
- Both v6 majors declare `using: node24` in their `action.yml`, so this preempts the GitHub-mandated Node 20 → Node 24 auto-switch on 2026-06-02 (forced removal 2026-09-16)
- Maintenance follow-up surfaced by sub-project A's final code review (71ee2e2); accepted tag-pinned tradeoff already documented in spec §7

## Test plan
- [ ] `test` workflow runs on this PR and goes green
- [ ] `make doctor` step still passes (validates pandoc, git config, python3.8 binary)
- [ ] `make test` step still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)