### PR TITLE
docs(A): post-C-rest housekeeping (test-count preamble + Makefile)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,5 +35,5 @@ doctor:  ## Run all read-only health checks (CI-suitable, exit 0/1)
 repair:  ## Apply idempotent fixes for issues doctor flags
 	@bash scripts/repair.sh
 
-test:  ## Run the full regression test suite (15 automated tests)
+test:  ## Run the full regression test suite (28 automated tests)
 	@bash scripts/test.sh

--- a/docs/superpowers/specs/2026-04-27-a-ci-tests-design.md
+++ b/docs/superpowers/specs/2026-04-27-a-ci-tests-design.md
@@ -8,6 +8,8 @@
 
 ---
 
+> **Test-count note (2026-04-28, sub-project C-rest)**: After A merged, C-rest extended the harness with T19–T31 (citation auditor), bringing the total to **28 automated tests** (T2–T31). The body of this document references "15 automated tests" because that was the count when A landed. The body is preserved as-shipped to keep the historical record honest; readers checking current behaviour should substitute 28.
+
 ## 1. Context
 
 D shipped a regression test harness (`scripts/test-foolproofing.sh`, 7 automated acceptance tests T2/T3/T4/T5/T8/T9/T10; T1/T6/T7 documented as manual-only because they require separate clones or PATH mutation that conflicts with parallel runs). C-emergency extended it with 8 more tests (T11–T18, covering status enum drift, vocab drift, allowed-tools sanity, Python 3.8 import safety, stale doc references). The harness now runs **15 automated tests on every invocation** and prints `all 15 tests passed` on `master @ 9092294`.


### PR DESCRIPTION
## Summary

- **A spec preamble**: add a *Test-count note (2026-04-28, sub-project C-rest)* blockquote at the top, mirroring the §4.1.1 *Rename note* pattern A applied to D and C-emergency after their facts went stale. Body of `2026-04-27-a-ci-tests-design.md` stays byte-identical (5 historical "15 tests" mentions preserved).
- **Makefile help text**: `test:  ## ... (15 → 28 automated tests)` to align with `scripts/test.sh:2` which C-rest already updated to "28 automated tests: T2-T18 toolkit + T19-T31 citation".

Out-of-tree changes (intentionally not in this PR — neither is git-trackable):
- `chmod +x .claude/skills/export/scripts/convert_to_docx.py` (local-only because `core.fileMode=false` toolkit-wide).
- Refreshed `project_toolkit_roadmap.md` auto-memory: D/C-em/A/C-rest shipped on master, B next (no spec yet).

§9 *References* itself was already fixed in #4 — no further change needed.

## Test plan

- [x] `make help | grep test` shows "28 automated tests"
- [x] `head -12 docs/superpowers/specs/2026-04-27-a-ci-tests-design.md` shows the new preamble at line 11
- [x] `grep -cE "(15 automated tests|all 15 tests|1 of 15 tests)" docs/superpowers/specs/2026-04-27-a-ci-tests-design.md` still returns the same count as before (body unchanged)
- [ ] CI `test` workflow goes green (28/28 — no behaviour change in this PR, only docs/help text)

🤖 Generated with [Claude Code](https://claude.com/claude-code)