### PR TITLE
[codex] add ChatGPT App MCP server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.github
+.DS_Store
+.playwright-mcp
+.worktrees
+node_modules
+apps/chatgpt-academic-writing-toolkit/node_modules
+__pycache__
+*.pyc
+*.docx
+*.pdf
+*.zip
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ Thumbs.db
 *.zip
 __pycache__/
 .env
+node_modules/
+.playwright-mcp/
 
 # Local worktrees (created by superpowers:using-git-worktrees skill)
 .worktrees/

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Run `make` (or `make help`) to see available targets.
 
 .DEFAULT_GOAL := help
-.PHONY: help setup init sync plugin-sync plugin-check doctor repair test
+.PHONY: help setup init sync plugin-sync plugin-check chatgpt-app-check doctor repair test
 
 EDITOR ?= vi
 
@@ -34,6 +34,9 @@ plugin-sync:  ## Regenerate the Codex plugin skills from .claude/skills
 
 plugin-check:  ## Validate the Codex plugin package and sync state
 	@bash scripts/check-plugin.sh
+
+chatgpt-app-check:  ## Run the ChatGPT App MCP server checks
+	@npm --prefix apps/chatgpt-academic-writing-toolkit test
 
 doctor:  ## Run all read-only health checks (CI-suitable, exit 0/1)
 	@bash scripts/doctor.sh

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Structured local agent skills for academic reading, writing, reference checking,
 
 This repository is a public toolkit. It contains reusable local agent skills, scripts, templates, and tests only. Put your own chapters, PDFs, notes, and private project material in your clone.
 
+The repository also includes distribution packaging for a Codex plugin and a tool-only ChatGPT App MCP server.
+
 ```
 /read -> /note -> /map -> /integrate -> /audit -> /style -> /logic-review -> /export
              |                         |
@@ -88,9 +90,11 @@ my-writing-project/
 ├── .claude/skills/          Claude Code skills
 ├── .agents/skills/          Symlinks for Codex, Gemini, and compatible agents
 ├── .cursor/rules/           Cursor baseline rules
+├── apps/                    ChatGPT App MCP server
 ├── chapters/                Your chapter drafts
 ├── literature/
 │   └── reading_notes/       One notes file per source
+├── plugins/                 Codex plugin package
 ├── final_output/            Exported documents
 ├── scripts/                 Deterministic helper checks
 ├── CLAUDE.md                Canonical project configuration
@@ -124,9 +128,10 @@ make test     # full regression suite
 make sync     # regenerate AGENTS.md and GEMINI.md
 make plugin-sync   # regenerate the Codex plugin skills from .claude/skills
 make plugin-check  # validate plugin metadata, sync state, and bundled helpers
+make chatgpt-app-check  # run the ChatGPT App MCP server checks
 ```
 
-For Codex plugin release preparation, use [`docs/plugin-publishing-checklist.md`](docs/plugin-publishing-checklist.md).
+For Codex plugin release preparation, use [`docs/plugin-publishing-checklist.md`](docs/plugin-publishing-checklist.md). For ChatGPT App deployment and submission preparation, use [`docs/chatgpt-app-publishing.md`](docs/chatgpt-app-publishing.md).
 
 The regression suite covers local skill discovery, config sync, export assumptions, citation auditing, public-content cleanup, British English checks, paragraph-logic checks, and offline plus fixture-backed reference verification.
 

--- a/apps/chatgpt-academic-writing-toolkit/Dockerfile
+++ b/apps/chatgpt-academic-writing-toolkit/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY apps/chatgpt-academic-writing-toolkit/package*.json ./apps/chatgpt-academic-writing-toolkit/
+RUN npm ci --prefix apps/chatgpt-academic-writing-toolkit --omit=dev
+
+COPY scripts ./scripts
+COPY apps/chatgpt-academic-writing-toolkit ./apps/chatgpt-academic-writing-toolkit
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+ENV NODE_ENV=production
+
+EXPOSE 3000
+
+CMD ["npm", "--prefix", "apps/chatgpt-academic-writing-toolkit", "start"]

--- a/apps/chatgpt-academic-writing-toolkit/README.md
+++ b/apps/chatgpt-academic-writing-toolkit/README.md
@@ -1,0 +1,42 @@
+# Academic Writing Toolkit ChatGPT App
+
+Tool-only ChatGPT App MCP server for academic writing checks.
+
+## Tools
+
+- `audit_citations`: checks pasted chapter text against pasted reading-note source lines.
+- `check_british_english`: finds conservative US-to-British spelling replacements.
+- `review_paragraph_logic`: flags short paragraphs and repeated adjacent transition words.
+- `verify_bibtex_references`: validates pasted BibTeX records offline.
+- `create_reading_note_template`: creates the standard reading-notes Markdown scaffold.
+
+The server processes user-provided text through temporary files only. It does not read local thesis files, persist user submissions, authenticate users, or call external metadata APIs.
+
+## Local Development
+
+```sh
+npm install
+npm test
+npm start
+```
+
+The server listens on `http://127.0.0.1:3000/mcp` by default. Override with:
+
+```sh
+HOST=0.0.0.0 PORT=3000 npm start
+```
+
+## Docker
+
+Build from the repository root so the image includes both this app and the shared Python scripts:
+
+```sh
+docker build -f apps/chatgpt-academic-writing-toolkit/Dockerfile -t academic-writing-toolkit-chatgpt-app .
+docker run --rm -p 3000:3000 academic-writing-toolkit-chatgpt-app
+```
+
+## Submission
+
+OpenAI app review requires a public HTTPS MCP URL, not a local endpoint. Deploy this app to a public host, then submit the hosted `/mcp` URL through OpenAI Platform Apps Manage.
+
+The review import file is `chatgpt-app-submission.json`.

--- a/apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json
+++ b/apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://developers.openai.com/apps-sdk/schemas/chatgpt-app-submission.v1.json",
+  "schema_version": 1,
+  "app_info": {
+    "display_name": "Academic Writing Toolkit",
+    "subtitle": "Review academic drafts",
+    "description": "Academic Writing Toolkit helps users review pasted academic writing materials in ChatGPT. It can audit citation consistency between draft prose and reading-note source lines, check conservative British English spelling, flag paragraph-level logic issues, validate BibTeX records offline, and create a standard reading-notes Markdown template.",
+    "category": "EDUCATION"
+  },
+  "tools": {
+    "audit_citations": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Computes citation audit findings from user-provided text and writes only temporary files during the tool call.",
+        "open_world_justification": "Does not write to public internet state or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "check_british_english": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Computes spelling findings and optional preview text from user-provided text without modifying user files.",
+        "open_world_justification": "Does not write to public internet state or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "review_paragraph_logic": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Computes paragraph-level review findings from user-provided text only.",
+        "open_world_justification": "Does not write to public internet state or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "verify_bibtex_references": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Performs offline validation of user-provided BibTeX and does not contact external metadata APIs.",
+        "open_world_justification": "Does not write to public internet state or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    },
+    "create_reading_note_template": {
+      "annotations": {
+        "readOnlyHint": true,
+        "openWorldHint": false,
+        "destructiveHint": false
+      },
+      "justifications": {
+        "read_only_justification": "Generates a Markdown template from user-provided source metadata without storing it.",
+        "open_world_justification": "Does not write to public internet state or third-party systems.",
+        "destructive_justification": "Does not delete, overwrite, revoke access, or perform irreversible actions."
+      }
+    }
+  },
+  "test_cases": [
+    {
+      "description": "Audit Harvard citation consistency between pasted chapter text and reading-note source lines.",
+      "user_prompt": "Check this draft citation against my reading note: chapter text 'Smith (2024) argues that archives shape interpretation.' reading note '**Source**: Jones, J. (2024) Title in sentence case. *Publisher*.'",
+      "file_attachment_urls": null,
+      "tools_triggered": "audit_citations",
+      "expected_output": "Returns citation audit findings that identify the unmatched in-text citation and the unused source.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Check British English spelling in pasted thesis prose.",
+      "user_prompt": "Please check this sentence for British English spelling: 'The color center helps analyze behavior.'",
+      "file_attachment_urls": null,
+      "tools_triggered": "check_british_english",
+      "expected_output": "Returns conservative replacement suggestions such as color to colour, center to centre, analyze to analyse, and behavior to behaviour.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Review paragraph logic for short paragraphs and repeated transitions.",
+      "user_prompt": "Review paragraph logic in this draft: 'However, this matters.\\n\\nHowever, it also matters.'",
+      "file_attachment_urls": null,
+      "tools_triggered": "review_paragraph_logic",
+      "expected_output": "Returns paragraph logic findings for short paragraphs and repeated adjacent transition wording.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Validate BibTeX records offline.",
+      "user_prompt": "Verify this BibTeX: @article{smith2024, title={Incomplete article}, year={2024}}",
+      "file_attachment_urls": null,
+      "tools_triggered": "verify_bibtex_references",
+      "expected_output": "Returns offline BibTeX validation findings, including missing required article fields.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Create a standard reading-note template for a source.",
+      "user_prompt": "Create a Harvard reading note template for Smith, J., Test Article, 2024, relevant to Ch2 S2.1.",
+      "file_attachment_urls": null,
+      "tools_triggered": "create_reading_note_template",
+      "expected_output": "Returns a Markdown reading notes template with Source, Date read, Status, Relevance, Key Arguments, Detailed Notes, Key Terms, Thesis Connections, and Questions sections.",
+      "expected_output_url": null
+    }
+  ],
+  "negative_test_cases": [
+    {
+      "description": "Do not trigger for general essay writing without a request for toolkit checks.",
+      "user_prompt": "Write a new essay about Renaissance literature.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because the user is asking ChatGPT to draft new prose rather than run an academic writing toolkit check.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for live web citation lookup.",
+      "user_prompt": "Search the web for the newest articles about climate policy.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because it does not perform web search or online metadata lookup.",
+      "expected_output_url": null
+    },
+    {
+      "description": "Do not trigger for local file operations.",
+      "user_prompt": "Open my local thesis folder and rewrite chapter 3.",
+      "file_attachment_urls": null,
+      "tools_triggered": null,
+      "expected_output": "The app should not be invoked because it only processes text the user provides in ChatGPT and does not access local files.",
+      "expected_output_url": null
+    }
+  ]
+}

--- a/apps/chatgpt-academic-writing-toolkit/package-lock.json
+++ b/apps/chatgpt-academic-writing-toolkit/package-lock.json
@@ -1,0 +1,1157 @@
+{
+  "name": "chatgpt-academic-writing-toolkit",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "chatgpt-academic-writing-toolkit",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.23.0",
+        "express": "^5.1.0",
+        "zod": "^4.1.12"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.1.tgz",
+      "integrity": "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.18",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
+      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/apps/chatgpt-academic-writing-toolkit/package.json
+++ b/apps/chatgpt-academic-writing-toolkit/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "chatgpt-academic-writing-toolkit",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Tool-only ChatGPT App MCP server for academic writing checks.",
+  "scripts": {
+    "test": "node --test",
+    "start": "node src/server.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.23.0",
+    "express": "^5.1.0",
+    "zod": "^4.1.12"
+  }
+}

--- a/apps/chatgpt-academic-writing-toolkit/src/server.js
+++ b/apps/chatgpt-academic-writing-toolkit/src/server.js
@@ -1,0 +1,144 @@
+import { pathToFileURL } from "node:url";
+
+import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+
+import { TOOL_DEFINITIONS } from "./tool-definitions.js";
+import {
+  auditCitations,
+  checkBritishEnglish,
+  createReadingNoteTemplate,
+  reviewParagraphLogic,
+  verifyBibtexReferences,
+} from "./tool-runner.js";
+
+const APP_NAME = "academic-writing-toolkit";
+const APP_VERSION = "1.0.0";
+
+const TOOL_HANDLERS = {
+  audit_citations: auditCitations,
+  check_british_english: checkBritishEnglish,
+  review_paragraph_logic: reviewParagraphLogic,
+  verify_bibtex_references: verifyBibtexReferences,
+  create_reading_note_template: createReadingNoteTemplate,
+};
+
+function contentFor(result) {
+  if (result.markdown) {
+    return result.markdown;
+  }
+  const preview = {
+    summary: result.summary,
+    issue_count: result.issue_count,
+    issues: result.issues?.slice(0, 20),
+  };
+  return JSON.stringify(preview, null, 2);
+}
+
+function asToolResult(result) {
+  return {
+    structuredContent: result,
+    content: [{ type: "text", text: contentFor(result) }],
+  };
+}
+
+export function createMcpServer() {
+  const server = new McpServer({
+    name: APP_NAME,
+    version: APP_VERSION,
+  });
+
+  for (const [name, descriptor] of Object.entries(TOOL_DEFINITIONS)) {
+    server.registerTool(name, descriptor, async (args) => {
+      const result = await TOOL_HANDLERS[name](args);
+      return asToolResult(result);
+    });
+  }
+
+  return server;
+}
+
+function methodNotAllowed(_req, res) {
+  res.status(405).json({
+    jsonrpc: "2.0",
+    error: {
+      code: -32000,
+      message: "Method not allowed.",
+    },
+    id: null,
+  });
+}
+
+export function createHttpApp({ host = process.env.HOST || "127.0.0.1" } = {}) {
+  const app = createMcpExpressApp({ host });
+
+  app.use((_req, res, next) => {
+    res.setHeader(
+      "Content-Security-Policy",
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+    );
+    next();
+  });
+
+  app.get("/health", (_req, res) => {
+    res.json({
+      name: APP_NAME,
+      version: APP_VERSION,
+      status: "ok",
+    });
+  });
+
+  app.post("/mcp", async (req, res) => {
+    const server = createMcpServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    try {
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      console.error("Error handling MCP request:", error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: "2.0",
+          error: {
+            code: -32603,
+            message: "Internal server error",
+          },
+          id: null,
+        });
+      }
+    } finally {
+      res.on("close", () => {
+        transport.close();
+        server.close();
+      });
+    }
+  });
+
+  app.get("/mcp", methodNotAllowed);
+  app.delete("/mcp", methodNotAllowed);
+
+  return app;
+}
+
+export function startHttpServer({
+  host = process.env.HOST || "127.0.0.1",
+  port = Number(process.env.PORT || 3000),
+} = {}) {
+  const app = createHttpApp({ host });
+  const server = app.listen(port, host, () => {
+    console.log(`${APP_NAME} MCP server listening on http://${host}:${port}/mcp`);
+  });
+  server.on("error", (error) => {
+    console.error("Failed to start server:", error);
+    process.exit(1);
+  });
+  return server;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  startHttpServer();
+}

--- a/apps/chatgpt-academic-writing-toolkit/src/tool-definitions.js
+++ b/apps/chatgpt-academic-writing-toolkit/src/tool-definitions.js
@@ -1,0 +1,130 @@
+import * as z from "zod/v4";
+
+const MAX_TEXT_CHARS = 100_000;
+const READ_ONLY_ANNOTATIONS = {
+  readOnlyHint: true,
+  openWorldHint: false,
+  destructiveHint: false,
+};
+
+const issueListSchema = z.array(z.record(z.string(), z.unknown()));
+const citationStyleSchema = z
+  .enum([
+    "harvard",
+    "apa",
+    "chicago-author-date",
+    "mla",
+    "ieee",
+    "vancouver",
+    "gb-t-7714-2015",
+  ])
+  .default("harvard");
+
+export const TOOL_DEFINITIONS = {
+  audit_citations: {
+    title: "Audit citations",
+    description:
+      "Use this when the user wants to check pasted academic prose against pasted reading-note source lines for citation consistency.",
+    inputSchema: {
+      chapterText: z
+        .string()
+        .min(1)
+        .max(MAX_TEXT_CHARS)
+        .describe("Chapter or draft text to audit."),
+      readingNotesText: z
+        .string()
+        .max(MAX_TEXT_CHARS)
+        .optional()
+        .default("")
+        .describe("Reading-note text containing one or more **Source** lines."),
+      style: citationStyleSchema.describe("Citation style to apply."),
+    },
+    outputSchema: {
+      schema_version: z.number(),
+      style: z.string().nullable(),
+      mode: z.string().nullable().optional(),
+      issue_count: z.number(),
+      issues: issueListSchema,
+      summary: z.string(),
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  check_british_english: {
+    title: "Check British English",
+    description:
+      "Use this when the user wants conservative British English spelling checks for pasted academic text.",
+    inputSchema: {
+      text: z.string().min(1).max(MAX_TEXT_CHARS).describe("Academic text to check."),
+      includeFixedText: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("Return a conservative fixed-text preview."),
+    },
+    outputSchema: {
+      schema_version: z.number(),
+      issue_count: z.number(),
+      issues: issueListSchema,
+      fixed_text: z.string().optional(),
+      summary: z.string(),
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  review_paragraph_logic: {
+    title: "Review paragraph logic",
+    description:
+      "Use this when the user wants a deterministic paragraph-level logic review of pasted chapter prose.",
+    inputSchema: {
+      text: z.string().min(1).max(MAX_TEXT_CHARS).describe("Chapter prose to review."),
+    },
+    outputSchema: {
+      schema_version: z.number(),
+      issue_count: z.number(),
+      issues: issueListSchema,
+      summary: z.string(),
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  verify_bibtex_references: {
+    title: "Verify BibTeX references",
+    description:
+      "Use this when the user wants offline validation of pasted BibTeX reference records.",
+    inputSchema: {
+      bibtex: z.string().min(1).max(MAX_TEXT_CHARS).describe("BibTeX records to validate."),
+    },
+    outputSchema: {
+      schema_version: z.number(),
+      entries: z.number(),
+      issue_count: z.number(),
+      issues: issueListSchema,
+      verified: issueListSchema,
+      metadata_checks: issueListSchema,
+      online_sources: z.array(z.string()),
+      summary: z.string(),
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+  create_reading_note_template: {
+    title: "Create reading note template",
+    description:
+      "Use this when the user wants a standard reading-notes Markdown template for a source.",
+    inputSchema: {
+      author: z.string().min(1).max(300).describe("Author name or author list."),
+      title: z.string().min(1).max(500).describe("Source title."),
+      year: z.string().min(1).max(20).describe("Publication year or date label."),
+      citationStyle: citationStyleSchema.describe("Citation style for the Source line hint."),
+      relevance: z
+        .string()
+        .max(500)
+        .optional()
+        .default("{e.g. Ch3 S3.2 - supports argument about X}")
+        .describe("Optional chapter or argument relevance note."),
+    },
+    outputSchema: {
+      schema_version: z.number(),
+      markdown: z.string(),
+      summary: z.string(),
+    },
+    annotations: READ_ONLY_ANNOTATIONS,
+  },
+};

--- a/apps/chatgpt-academic-writing-toolkit/src/tool-runner.js
+++ b/apps/chatgpt-academic-writing-toolkit/src/tool-runner.js
@@ -1,0 +1,234 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const SOURCE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = path.resolve(SOURCE_DIR, "..");
+const REPO_ROOT = path.resolve(APP_ROOT, "../..");
+const SCRIPTS_DIR = path.join(REPO_ROOT, "scripts");
+
+function summarize(kind, count) {
+  if (count === 0) {
+    return `${kind}: no issues found.`;
+  }
+  return `${kind}: ${count} issue${count === 1 ? "" : "s"} found.`;
+}
+
+async function withTempProject(callback) {
+  const baseDir = await mkdtemp(path.join(tmpdir(), "awt-chatgpt-"));
+  try {
+    await mkdir(path.join(baseDir, "chapters"), { recursive: true });
+    await mkdir(path.join(baseDir, "literature", "reading_notes"), { recursive: true });
+    return await callback(baseDir);
+  } finally {
+    await rm(baseDir, { recursive: true, force: true });
+  }
+}
+
+function runPythonScript(scriptName, args, { allowIssuesExit = true } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("python3", [path.join(SCRIPTS_DIR, scriptName), ...args], {
+      cwd: REPO_ROOT,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.setEncoding("utf8");
+    child.stderr.setEncoding("utf8");
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code !== 0 && !(allowIssuesExit && code === 1)) {
+        reject(new Error(`${scriptName} exited ${code}: ${stderr || stdout}`));
+        return;
+      }
+      resolve({ stdout, stderr, code });
+    });
+  });
+}
+
+function parseJson(stdout, scriptName) {
+  try {
+    return JSON.parse(stdout);
+  } catch (error) {
+    throw new Error(`Could not parse JSON from ${scriptName}: ${error.message}`);
+  }
+}
+
+export async function auditCitations({ chapterText, readingNotesText = "", style = "harvard" }) {
+  return withTempProject(async (baseDir) => {
+    await writeFile(path.join(baseDir, "chapters", "input.md"), chapterText, "utf8");
+    if (readingNotesText.trim()) {
+      await writeFile(
+        path.join(baseDir, "literature", "reading_notes", "input_NOTES.md"),
+        readingNotesText,
+        "utf8",
+      );
+    }
+
+    const { stdout } = await runPythonScript("audit-citations.py", [
+      "--base-dir",
+      baseDir,
+      "--style",
+      style,
+      "--json",
+    ]);
+    const payload = parseJson(stdout, "audit-citations.py");
+    const issueCount = payload.issue_count ?? payload.issues?.length ?? 0;
+    return {
+      schema_version: payload.schema_version,
+      style: payload.style ?? style,
+      mode: payload.mode ?? null,
+      issues: payload.issues ?? [],
+      issue_count: issueCount,
+      summary: summarize("Citation audit", issueCount),
+    };
+  });
+}
+
+export async function checkBritishEnglish({ text, includeFixedText = false }) {
+  return withTempProject(async (baseDir) => {
+    const inputPath = path.join(baseDir, "chapters", "input.md");
+    await writeFile(inputPath, text, "utf8");
+
+    const { stdout } = await runPythonScript("audit-british-english.py", [
+      "--base-dir",
+      baseDir,
+      "--json",
+    ]);
+    const payload = parseJson(stdout, "audit-british-english.py");
+    const result = {
+      ...payload,
+      summary: summarize("British English check", payload.issue_count ?? 0),
+    };
+
+    if (includeFixedText) {
+      await runPythonScript("audit-british-english.py", [
+        "--base-dir",
+        baseDir,
+        "--fix",
+        "--json",
+      ]);
+      result.fixed_text = await readFile(inputPath, "utf8");
+    }
+
+    return result;
+  });
+}
+
+export async function reviewParagraphLogic({ text }) {
+  return withTempProject(async (baseDir) => {
+    await writeFile(path.join(baseDir, "chapters", "input.md"), text, "utf8");
+    const { stdout } = await runPythonScript("audit-logic.py", [
+      "--base-dir",
+      baseDir,
+      "--json",
+    ]);
+    const payload = parseJson(stdout, "audit-logic.py");
+    return {
+      ...payload,
+      summary: summarize("Paragraph logic review", payload.issue_count ?? 0),
+    };
+  });
+}
+
+export async function verifyBibtexReferences({ bibtex }) {
+  return withTempProject(async (baseDir) => {
+    const bibPath = path.join(baseDir, "references.bib");
+    await writeFile(bibPath, bibtex, "utf8");
+    const { stdout } = await runPythonScript("verify-refs.py", [
+      "--bib",
+      bibPath,
+      "--json",
+    ]);
+    const payload = parseJson(stdout, "verify-refs.py");
+    return {
+      ...payload,
+      summary: summarize("BibTeX reference verification", payload.issue_count ?? 0),
+    };
+  });
+}
+
+function sourceLineFor(style, author, title, year) {
+  switch (style) {
+    case "apa":
+      return `${author} (${year}). ${title}. *Publisher*.`;
+    case "chicago-author-date":
+      return `${author}. ${year}. *${title}*. Publisher.`;
+    case "mla":
+      return `${author}. *${title}*. Publisher, ${year}.`;
+    case "ieee":
+      return `[1] ${author}, "${title}," *Journal*, ${year}.`;
+    case "vancouver":
+      return `1. ${author}. ${title}. Journal. ${year}.`;
+    case "gb-t-7714-2015":
+      return `${author}. ${title}[J]. *Journal*, ${year}.`;
+    case "harvard":
+    default:
+      return `${author} (${year}) ${title}. *Publisher*.`;
+  }
+}
+
+export function createReadingNoteTemplate({
+  author,
+  title,
+  year,
+  citationStyle = "harvard",
+  relevance = "{e.g. Ch3 S3.2 - supports argument about X}",
+}) {
+  const markdown = `# Reading Notes: ${author} - ${title} (${year})
+
+**Source**: ${sourceLineFor(citationStyle, author, title, year)}
+**Date read**: {YYYY-MM-DD}
+**Status**: reading
+**Relevance**: ${relevance}
+
+---
+
+## Key Arguments
+
+- {Main argument 1}
+- {Main argument 2}
+
+## Detailed Notes
+
+### p.{N}-{M}: {Section Title}
+
+> "{direct quote}" (p.{N})
+
+{Your analysis and commentary}
+
+## Key Terms
+
+| Term | Translation | Definition in context |
+|------|-------------|-----------------------|
+| {term} | {translation if applicable} | {meaning in this text} |
+
+## Thesis Connections
+
+| Note Point | Chapter | Section | Connection Type |
+|------------|---------|---------|-----------------|
+| {concept} | Ch{N} | S{N.M} | supports / challenges / extends |
+
+## Questions & Follow-ups
+
+- {Open questions for future reading}
+
+---
+*Last updated: {YYYY-MM-DD}*
+`;
+
+  return {
+    schema_version: 1,
+    markdown,
+    summary: "Reading note template created.",
+  };
+}

--- a/apps/chatgpt-academic-writing-toolkit/test/server.test.js
+++ b/apps/chatgpt-academic-writing-toolkit/test/server.test.js
@@ -1,0 +1,33 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { createHttpApp } from "../src/server.js";
+
+test("HTTP app exposes health and guards non-POST MCP requests", async () => {
+  const app = createHttpApp({ host: "127.0.0.1" });
+  const server = await new Promise((resolve) => {
+    const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+
+  try {
+    const port = server.address().port;
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+    assert.equal(health.status, 200);
+    assert.equal(
+      health.headers.get("content-security-policy"),
+      "default-src 'none'; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+    );
+    assert.deepEqual(await health.json(), {
+      name: "academic-writing-toolkit",
+      version: "1.0.0",
+      status: "ok",
+    });
+
+    const mcpGet = await fetch(`http://127.0.0.1:${port}/mcp`);
+    assert.equal(mcpGet.status, 405);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/apps/chatgpt-academic-writing-toolkit/test/tool-runner.test.js
+++ b/apps/chatgpt-academic-writing-toolkit/test/tool-runner.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  auditCitations,
+  checkBritishEnglish,
+  createReadingNoteTemplate,
+  reviewParagraphLogic,
+  verifyBibtexReferences,
+} from "../src/tool-runner.js";
+import { TOOL_DEFINITIONS } from "../src/tool-definitions.js";
+
+test("checkBritishEnglish reports conservative US spelling replacements", async () => {
+  const result = await checkBritishEnglish({
+    text: "The color center helps analyze behavior.",
+  });
+
+  assert.equal(result.issue_count, 4);
+  assert.deepEqual(
+    result.issues.map((issue) => `${issue.current}->${issue.replacement}`),
+    ["color->colour", "center->centre", "analyze->analyse", "behavior->behaviour"],
+  );
+});
+
+test("reviewParagraphLogic flags short paragraphs and repeated transitions", async () => {
+  const result = await reviewParagraphLogic({
+    text: "However, this matters.\n\nHowever, it also matters.",
+  });
+
+  const kinds = new Set(result.issues.map((issue) => issue.kind));
+  assert.equal(result.issue_count, 3);
+  assert.equal(kinds.has("short-paragraph"), true);
+  assert.equal(kinds.has("repeated-transition"), true);
+});
+
+test("verifyBibtexReferences validates BibTeX offline", async () => {
+  const result = await verifyBibtexReferences({
+    bibtex: `@article{smith2024,
+  title={Incomplete article},
+  year={2024}
+}
+
+@article{smith2024,
+  title={Complete article},
+  author={Smith, Jane},
+  year={2024},
+  journal={Journal of Tests},
+  doi={not-a-doi}
+}
+`,
+  });
+
+  const kinds = new Set(result.issues.map((issue) => issue.kind));
+  assert.equal(result.entries, 2);
+  assert.equal(kinds.has("duplicate-key"), true);
+  assert.equal(kinds.has("missing-required-field"), true);
+  assert.equal(kinds.has("doi-invalid"), true);
+});
+
+test("auditCitations compares chapter text with reading-note sources", async () => {
+  const result = await auditCitations({
+    style: "harvard",
+    chapterText: "Smith (2024) argues that the archive changes interpretation.",
+    readingNotesText: "**Source**: Jones, J. (2024) Title in sentence case. *Publisher*.",
+  });
+
+  assert.equal(result.style, "harvard");
+  assert.equal(result.issue_count > 0, true);
+  assert.equal(Array.isArray(result.issues), true);
+});
+
+test("createReadingNoteTemplate returns the standard notes structure", () => {
+  const result = createReadingNoteTemplate({
+    author: "Smith, J.",
+    title: "Test Article",
+    year: "2024",
+    citationStyle: "harvard",
+    relevance: "Ch2 S2.1 - background context",
+  });
+
+  assert.match(result.markdown, /^# Reading Notes: Smith, J\. - Test Article \(2024\)/);
+  assert.match(result.markdown, /\*\*Status\*\*: reading/);
+  assert.match(result.markdown, /## Key Arguments/);
+  assert.match(result.markdown, /Ch2 S2\.1 - background context/);
+});
+
+test("all ChatGPT tool descriptors declare review hints and output schemas", () => {
+  const expectedNames = [
+    "audit_citations",
+    "check_british_english",
+    "review_paragraph_logic",
+    "verify_bibtex_references",
+    "create_reading_note_template",
+  ];
+
+  assert.deepEqual(Object.keys(TOOL_DEFINITIONS).sort(), expectedNames.sort());
+  for (const [name, descriptor] of Object.entries(TOOL_DEFINITIONS)) {
+    assert.equal(descriptor.description.startsWith("Use this when"), true, name);
+    assert.deepEqual(descriptor.annotations, {
+      readOnlyHint: true,
+      openWorldHint: false,
+      destructiveHint: false,
+    });
+    assert.ok(descriptor.outputSchema, `${name} is missing outputSchema`);
+  }
+});

--- a/docs/chatgpt-app-design.md
+++ b/docs/chatgpt-app-design.md
@@ -1,0 +1,51 @@
+# ChatGPT App Design: Academic Writing Toolkit
+
+## Decision
+
+Build a `tool-only` ChatGPT App for the Academic Writing Toolkit while keeping the existing Codex plugin package intact.
+
+This gives the project two distribution tracks:
+
+- ChatGPT App: public MCP server submitted through OpenAI Platform Apps Manage.
+- Codex plugin: local plugin package under `plugins/academic-writing-toolkit`, with official public distribution following OpenAI's app approval and publication flow.
+
+## User Flows
+
+1. A user pastes a thesis paragraph and asks for British English spelling checks.
+2. A user pastes a chapter excerpt and reading note source line, then asks for Harvard citation consistency checks.
+3. A user asks for paragraph-level logic review before revising a chapter.
+4. A user pastes BibTeX and asks for deterministic reference validation.
+5. A user asks ChatGPT to create a reading notes template for a source before taking notes.
+
+## Tool Surface
+
+- `audit_citations`: Checks pasted chapter text against pasted reading note source text using the repository citation auditor.
+- `check_british_english`: Finds conservative US-to-British spelling replacements in pasted academic text.
+- `review_paragraph_logic`: Flags short paragraphs and repeated adjacent transition words.
+- `verify_bibtex_references`: Validates pasted BibTeX records offline.
+- `create_reading_note_template`: Produces a standard reading notes Markdown template.
+
+All tools are read-only from the user's perspective. They compute results from user-provided text, write only temporary local files during the tool call, do not persist user data, do not call external APIs, and do not mutate local thesis files.
+
+## Review Constraints
+
+- No ChatGPT widget in v1.
+- No authentication in v1.
+- No direct local filesystem access from ChatGPT.
+- No online metadata verification in v1.
+- Every tool must declare explicit `readOnlyHint`, `openWorldHint`, and `destructiveHint` annotations.
+- Every tool should declare an `outputSchema`.
+- Submission metadata must include at least five positive test cases and three negative test cases.
+
+## Implementation Plan
+
+1. Create an isolated Node MCP server under `apps/chatgpt-academic-writing-toolkit`.
+2. Wrap existing deterministic Python scripts through a temporary project directory.
+3. Add Node tests for the five user-facing tool helpers.
+4. Register the five tools on `/mcp` using the Apps SDK/MCP server pattern.
+5. Generate `chatgpt-app-submission.json` from the implemented tool descriptors.
+6. Add a Make target for the ChatGPT app checks.
+
+## Deployment Note
+
+OpenAI submission requires a public MCP URL, not a localhost endpoint. This repo prepares the app and submission JSON; a hosting target must provide the final HTTPS `/mcp` URL before dashboard submission.

--- a/docs/chatgpt-app-publishing.md
+++ b/docs/chatgpt-app-publishing.md
@@ -1,0 +1,66 @@
+# ChatGPT App Publishing Notes
+
+This project now includes a tool-only ChatGPT App implementation at:
+
+`apps/chatgpt-academic-writing-toolkit/`
+
+## Local Checks
+
+Run from the repository root:
+
+```bash
+make chatgpt-app-check
+make plugin-check
+make test
+```
+
+The app-specific check runs the Node test suite for the MCP server and tool wrappers.
+
+## Review Artifacts
+
+- MCP server path: `apps/chatgpt-academic-writing-toolkit/src/server.js`
+- Submission import file: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
+- Privacy URL source: `docs/privacy.md`
+- Terms URL source: `docs/terms.md`
+
+## Deployment Requirement
+
+OpenAI Apps submission requires a public HTTPS MCP server URL. Localhost and temporary testing endpoints are not valid for review.
+
+Deploy the app so this endpoint is reachable:
+
+```text
+https://YOUR_DOMAIN/mcp
+```
+
+Use these environment variables on the host:
+
+```sh
+HOST=0.0.0.0
+PORT=3000
+```
+
+## Docker Deployment
+
+Build from the repository root:
+
+```sh
+docker build -f apps/chatgpt-academic-writing-toolkit/Dockerfile -t academic-writing-toolkit-chatgpt-app .
+docker run --rm -p 3000:3000 academic-writing-toolkit-chatgpt-app
+```
+
+For hosted deployment, configure the platform to route HTTPS traffic to container port `3000` and submit the public `https://YOUR_DOMAIN/mcp` URL.
+
+## Official Review Flow
+
+Use OpenAI Platform Apps Manage after deployment:
+
+https://platform.openai.com/apps-manage
+
+OpenAI's Apps SDK submission docs state that the dashboard app review flow is the current path to public distribution, and that publishing an approved app creates the Codex distribution plugin. Self-serve standalone Codex plugin publishing is documented as coming soon.
+
+Relevant docs:
+
+- https://developers.openai.com/apps-sdk/deploy/submission
+- https://developers.openai.com/apps-sdk/app-submission-guidelines
+- https://developers.openai.com/apps-sdk/build/mcp-server

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,10 +1,14 @@
 # Privacy Policy
 
-Academic Writing Toolkit is a local Codex plugin for research and thesis-writing workflows.
+Academic Writing Toolkit supports research and thesis-writing workflows as a local Codex plugin and as a tool-only ChatGPT App.
 
 The plugin does not operate a hosted service, create user accounts, or intentionally collect analytics. Skills run in the user's local Codex workspace and read or write only the project files the user asks Codex to work with, such as chapters, literature notes, references, and export output.
 
+The ChatGPT App version processes only text the user provides to ChatGPT for the current tool call. It writes temporary files during processing, deletes them after the request, does not create user accounts, does not intentionally collect analytics, and does not persist submitted academic text.
+
 Some skills can use network access only when the user explicitly requests online verification, such as `/verify` fact-checking or `/verify-refs --online` metadata checks. In those cases, Codex may contact third-party sources such as CrossRef, Semantic Scholar, arXiv, or web pages relevant to the user's request. The plugin does not receive or store those requests separately.
+
+The ChatGPT App submission build does not perform online metadata verification in its tools.
 
 Users should not put confidential research material into public repositories or share exported outputs unless they intend to disclose that material.
 

--- a/docs/terms.md
+++ b/docs/terms.md
@@ -4,6 +4,6 @@ Academic Writing Toolkit is provided under the MIT License. It is intended to su
 
 The toolkit is provided "as is" without warranty. Users are responsible for reviewing all generated notes, edits, citation reports, reference checks, and exported documents before submission or publication.
 
-The plugin does not replace academic supervision, institutional review, publisher requirements, legal advice, or formal reference-management tools. Online metadata checks depend on third-party services and may be incomplete or unavailable.
+The toolkit does not replace academic supervision, institutional review, publisher requirements, legal advice, or formal reference-management tools. Online metadata checks in the local toolkit depend on third-party services and may be incomplete or unavailable. The ChatGPT App submission build uses offline checks only.
 
 Use of this toolkit is also subject to the repository license: https://github.com/yha9806/academic-writing-toolkit/blob/master/LICENSE


### PR DESCRIPTION
## Summary

- Add a tool-only ChatGPT App MCP server for Academic Writing Toolkit under `apps/chatgpt-academic-writing-toolkit`.
- Expose citation audit, British English, paragraph logic, BibTeX validation, and reading-note template tools with explicit Apps SDK annotations and output schemas.
- Add review submission JSON, publishing notes, privacy/terms updates, and Docker deployment packaging.

## Validation

- `make chatgpt-app-check`
- `make plugin-check`
- `make test`
- MCP smoke test: `initialize` and `tools/list` against local `/mcp` returned expected responses.

## Notes

OpenAI app submission still requires a public HTTPS `/mcp` URL. This PR prepares the deployable app and review packet; deploy the container or Node service before submitting in Apps Manage.
