### PR TITLE
[codex] support OpenAI app domain challenge

### DIFF
--- a/apps/chatgpt-academic-writing-toolkit/src/server.js
+++ b/apps/chatgpt-academic-writing-toolkit/src/server.js
@@ -89,6 +89,15 @@ export function createHttpApp({ host = process.env.HOST || "127.0.0.1" } = {}) {
     });
   });
 
+  app.get("/.well-known/openai-apps-challenge", (_req, res) => {
+    const challenge = process.env.OPENAI_APPS_CHALLENGE;
+    if (!challenge) {
+      res.status(404).type("text/plain").send("OpenAI Apps challenge is not configured.");
+      return;
+    }
+    res.type("text/plain").send(challenge);
+  });
+
   app.post("/mcp", async (req, res) => {
     const server = createMcpServer();
     const transport = new StreamableHTTPServerTransport({

--- a/apps/chatgpt-academic-writing-toolkit/test/server.test.js
+++ b/apps/chatgpt-academic-writing-toolkit/test/server.test.js
@@ -4,6 +4,8 @@ import assert from "node:assert/strict";
 import { createHttpApp } from "../src/server.js";
 
 test("HTTP app exposes health and guards non-POST MCP requests", async () => {
+  const oldChallenge = process.env.OPENAI_APPS_CHALLENGE;
+  process.env.OPENAI_APPS_CHALLENGE = "test-openai-apps-challenge";
   const app = createHttpApp({ host: "127.0.0.1" });
   const server = await new Promise((resolve) => {
     const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
@@ -25,7 +27,16 @@ test("HTTP app exposes health and guards non-POST MCP requests", async () => {
 
     const mcpGet = await fetch(`http://127.0.0.1:${port}/mcp`);
     assert.equal(mcpGet.status, 405);
+
+    const challenge = await fetch(`http://127.0.0.1:${port}/.well-known/openai-apps-challenge`);
+    assert.equal(challenge.status, 200);
+    assert.equal(await challenge.text(), "test-openai-apps-challenge");
   } finally {
+    if (oldChallenge === undefined) {
+      delete process.env.OPENAI_APPS_CHALLENGE;
+    } else {
+      process.env.OPENAI_APPS_CHALLENGE = oldChallenge;
+    }
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });


### PR DESCRIPTION
## Summary

- Add an environment-driven `/.well-known/openai-apps-challenge` route for OpenAI Apps domain verification.
- Cover the route in the ChatGPT App server test.

## Validation

- `make chatgpt-app-check`
- `make test`
