### PR TITLE
[codex] release readiness for app submission

### DIFF
--- a/apps/chatgpt-academic-writing-toolkit/package-lock.json
+++ b/apps/chatgpt-academic-writing-toolkit/package-lock.json
@@ -834,9 +834,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/apps/chatgpt-academic-writing-toolkit/package-lock.json
+++ b/apps/chatgpt-academic-writing-toolkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-academic-writing-toolkit",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-academic-writing-toolkit",
-      "version": "1.0.0",
+      "version": "0.2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",
         "express": "^5.1.0",

--- a/apps/chatgpt-academic-writing-toolkit/package.json
+++ b/apps/chatgpt-academic-writing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-academic-writing-toolkit",
-  "version": "1.0.0",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "description": "Tool-only ChatGPT App MCP server for academic writing checks.",

--- a/apps/chatgpt-academic-writing-toolkit/src/server.js
+++ b/apps/chatgpt-academic-writing-toolkit/src/server.js
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
@@ -14,7 +15,8 @@ import {
 } from "./tool-runner.js";
 
 const APP_NAME = "academic-writing-toolkit";
-const APP_VERSION = "1.0.0";
+const APP_PACKAGE = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
+const APP_VERSION = APP_PACKAGE.version;
 
 const TOOL_HANDLERS = {
   audit_citations: auditCitations,

--- a/apps/chatgpt-academic-writing-toolkit/test/server.test.js
+++ b/apps/chatgpt-academic-writing-toolkit/test/server.test.js
@@ -1,9 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 
 import { createHttpApp } from "../src/server.js";
 
-test("HTTP app exposes health and guards non-POST MCP requests", async () => {
+async function readJson(url) {
+  return JSON.parse(await readFile(url, "utf8"));
+}
+
+test("HTTP app exposes package-aligned health and guards non-POST MCP requests", async () => {
+  const appPackage = await readJson(new URL("../package.json", import.meta.url));
+  const pluginManifest = await readJson(
+    new URL("../../../plugins/academic-writing-toolkit/.codex-plugin/plugin.json", import.meta.url),
+  );
+  assert.equal(appPackage.version, pluginManifest.version);
+
   const oldChallenge = process.env.OPENAI_APPS_CHALLENGE;
   process.env.OPENAI_APPS_CHALLENGE = "test-openai-apps-challenge";
   const app = createHttpApp({ host: "127.0.0.1" });
@@ -21,7 +32,7 @@ test("HTTP app exposes health and guards non-POST MCP requests", async () => {
     );
     assert.deepEqual(await health.json(), {
       name: "academic-writing-toolkit",
-      version: "1.0.0",
+      version: appPackage.version,
       status: "ok",
     });
 

--- a/docs/chatgpt-app-design.md
+++ b/docs/chatgpt-app-design.md
@@ -9,6 +9,8 @@ This gives the project two distribution tracks:
 - ChatGPT App: public MCP server submitted through OpenAI Platform Apps Manage.
 - Codex plugin: local plugin package under `plugins/academic-writing-toolkit`, with official public distribution following OpenAI's app approval and publication flow.
 
+Both surfaces use package version `0.2.0` for this release. The ChatGPT App server reads its version from `apps/chatgpt-academic-writing-toolkit/package.json`, and the test suite checks that it matches the Codex plugin manifest version.
+
 ## User Flows
 
 1. A user pastes a thesis paragraph and asks for British English spelling checks.
@@ -26,6 +28,24 @@ This gives the project two distribution tracks:
 - `create_reading_note_template`: Produces a standard reading notes Markdown template.
 
 All tools are read-only from the user's perspective. They compute results from user-provided text, write only temporary local files during the tool call, do not persist user data, do not call external APIs, and do not mutate local thesis files.
+
+## Surface Alignment
+
+The ChatGPT App intentionally exposes a review-safe subset of the local Codex plugin:
+
+| Capability | Codex plugin | ChatGPT App |
+|------------|--------------|-------------|
+| Read PDFs and create local notes | `/read`, `/note` | Not exposed; ChatGPT App has no local file access |
+| Map and integrate sources into chapters | `/map`, `/integrate` | Not exposed; requires workspace files |
+| Evidence-controlled review synthesis | `/evidence-review` | Not exposed; requires local notes and project artefacts |
+| Citation audit | `/audit` | `audit_citations` for pasted text and source lines |
+| British English check | `/style` | `check_british_english` for pasted text |
+| Paragraph logic review | `/logic-review` | `review_paragraph_logic` for pasted text |
+| BibTeX/reference validation | `/verify-refs` | `verify_bibtex_references` offline only |
+| Reading note scaffold | `/note` template workflow | `create_reading_note_template` |
+| Progress and export | `/progress`, `/export` | Not exposed; requires local workspace files |
+
+This is functional alignment by workflow, not one-to-one feature parity. The plugin remains the full local workspace product; the ChatGPT App is the safe hosted review surface for user-provided text.
 
 ## Review Constraints
 

--- a/docs/chatgpt-app-publishing.md
+++ b/docs/chatgpt-app-publishing.md
@@ -22,6 +22,7 @@ The app-specific check runs the Node test suite for the MCP server and tool wrap
 - Submission import file: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
 - Privacy URL source: `docs/privacy.md`
 - Terms URL source: `docs/terms.md`
+- App package version: `0.2.0`, aligned with `plugins/academic-writing-toolkit/.codex-plugin/plugin.json`
 
 ## Deployment Requirement
 
@@ -38,7 +39,17 @@ Use these environment variables on the host:
 ```sh
 HOST=0.0.0.0
 PORT=3000
+OPENAI_APPS_CHALLENGE=<challenge value from OpenAI Platform, when requested>
 ```
+
+Before submission, verify the hosted deployment from outside local or private networks:
+
+```sh
+curl -fsS https://YOUR_DOMAIN/health
+curl -i https://YOUR_DOMAIN/mcp
+```
+
+`/health` should return the app name, version, and `status: ok`. `GET /mcp` should return `405`; MCP traffic uses `POST /mcp`.
 
 ## Docker Deployment
 
@@ -50,6 +61,19 @@ docker run --rm -p 3000:3000 academic-writing-toolkit-chatgpt-app
 ```
 
 For hosted deployment, configure the platform to route HTTPS traffic to container port `3000` and submit the public `https://YOUR_DOMAIN/mcp` URL.
+
+## Review Checklist
+
+Before pressing Submit for review:
+
+- Complete OpenAI organization verification for the publisher name.
+- Confirm the submitting account has `api.apps.write`; use `api.apps.read` to view drafts and review status.
+- Use a public HTTPS MCP URL that OpenAI can reach during automated checks and manual review.
+- Import `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json` into the dashboard form and re-check every generated test case.
+- Run the positive and negative test prompts in ChatGPT Developer Mode on web and mobile; expected outputs should be concise and match the stated tool behavior.
+- Confirm every tool descriptor has explicit `readOnlyHint`, `openWorldHint`, `destructiveHint`, and `outputSchema`.
+- Audit realistic tool responses for unnecessary personal data, debug fields, request IDs, logs, or secrets before submission.
+- Confirm `docs/privacy.md` and `docs/terms.md` match the deployed app behaviour.
 
 ## Official Review Flow
 

--- a/docs/openai-codex-plugin-submission.md
+++ b/docs/openai-codex-plugin-submission.md
@@ -4,12 +4,13 @@ This file records the official-format submission details for the Academic Writin
 
 ## Official Status
 
-As of 2026-05-13, OpenAI's Codex plugin build documentation says official public plugin publishing and self-serve plugin management are coming soon.
+As of 2026-05-31, OpenAI's Codex plugin build documentation says official public plugin publishing and self-serve plugin management are coming soon. OpenAI's Apps submission documentation says the current public distribution path is to submit a ChatGPT App through the dashboard; publishing an approved app creates the Codex distribution plugin.
 
 Official docs:
 
 - https://developers.openai.com/codex/plugins
 - https://developers.openai.com/codex/plugins/build
+- https://developers.openai.com/apps-sdk/deploy/submission
 
 This package is prepared to match the official Codex plugin package format. It has not been submitted to an official OpenAI public Plugin Directory because the official self-serve submission surface is not yet available in the documented developer flow.
 
@@ -18,16 +19,26 @@ This package is prepared to match the official Codex plugin package format. It h
 - Plugin name: `academic-writing-toolkit`
 - Display name: `Academic Writing Toolkit`
 - Repository: `https://github.com/yha9806/academic-writing-toolkit`
-- Release ref: `v0.1.0`
+- Package version: `0.2.0`
+- Tagged release ref for external review: `v0.2.0` after creating the verified release tag
 - Current default branch ref used for local marketplace tracking: `master`
 - Plugin path: `plugins/academic-writing-toolkit`
 - Manifest: `plugins/academic-writing-toolkit/.codex-plugin/plugin.json`
 - Marketplace metadata for repo/team testing: `.agents/plugins/marketplace.json`
+- ChatGPT App submission import: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
 
 ## Install Command For Review
 
+Use `master` for current default-branch testing:
+
 ```bash
-codex marketplace add yha9806/academic-writing-toolkit --ref v0.1.0 --sparse .agents/plugins --sparse plugins/academic-writing-toolkit
+codex marketplace add yha9806/academic-writing-toolkit --ref master --sparse .agents/plugins --sparse plugins/academic-writing-toolkit
+```
+
+Use an immutable release tag after the `v0.2.0` tag has been created:
+
+```bash
+codex marketplace add yha9806/academic-writing-toolkit --ref v0.2.0 --sparse .agents/plugins --sparse plugins/academic-writing-toolkit
 ```
 
 The local CLI currently exposes `codex marketplace add`. Some newer OpenAI docs show `codex plugin marketplace add`; use the command supported by the installed Codex CLI version.
@@ -49,6 +60,7 @@ The manifest follows the OpenAI Codex plugin docs:
 - `note`
 - `verify`
 - `map`
+- `evidence-review`
 - `integrate`
 - `audit`
 - `style`
@@ -59,10 +71,11 @@ The manifest follows the OpenAI Codex plugin docs:
 
 ## Review Notes
 
-- The plugin is a Codex plugin package, not a ChatGPT Apps SDK app.
-- `chatgpt-app-submission.json` is not generated because this repo does not expose a ChatGPT Apps MCP server or Apps SDK widget surface.
+- The standalone plugin package is a Codex plugin package with bundled local skills and helper scripts.
+- The repository also exposes a separate tool-only ChatGPT App MCP server under `apps/chatgpt-academic-writing-toolkit/`.
+- `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json` is generated for the OpenAI Platform Apps dashboard review flow.
 - The package uses bundled local skills and helper scripts only.
-- The package does not declare an external app connector or MCP server.
+- The standalone plugin manifest does not currently declare `.app.json` or `.mcp.json`; public Codex distribution should follow the documented Apps approval and publication path until self-serve plugin publishing is available.
 
 ## Verification
 
@@ -71,6 +84,7 @@ Run from the repository root before any official submission:
 ```bash
 make plugin-sync
 make plugin-check
+make chatgpt-app-check
 make test
 ```
 
@@ -80,6 +94,7 @@ Expected result:
 - plugin manifest and marketplace metadata validate
 - helper scripts expose usable `--help`
 - PNG asset paths and headers validate
+- ChatGPT App tool descriptors and wrappers pass their Node test suite
 - regression tests pass
 
 ## Community Submission Note


### PR DESCRIPTION
## Summary
- Fix the ChatGPT App dependency audit by bumping the transitive `qs` lockfile entry to `6.15.2`.
- Align the ChatGPT App package/server version with the Codex plugin manifest at `0.2.0` and add a regression test for version drift.
- Refresh App/Codex submission docs with the current OpenAI review path, public HTTPS MCP checklist, and plugin/App surface alignment.

## Test Plan
- `npm --prefix apps/chatgpt-academic-writing-toolkit ci`
- `make doctor`
- `make plugin-check`
- `make chatgpt-app-check`
- `npm --prefix apps/chatgpt-academic-writing-toolkit audit --json`
- `make test`

## Notes
- ChatGPT App and Codex plugin versions are now unified at `0.2.0`.
- Functionality is aligned by workflow, not one-to-one: the plugin remains the full local workspace surface, while the ChatGPT App exposes the safe pasted-text subset for hosted review.