### PR TITLE
[codex] add Render deployment blueprint

### DIFF
--- a/docs/chatgpt-app-publishing.md
+++ b/docs/chatgpt-app-publishing.md
@@ -62,6 +62,48 @@ docker run --rm -p 3000:3000 academic-writing-toolkit-chatgpt-app
 
 For hosted deployment, configure the platform to route HTTPS traffic to container port `3000` and submit the public `https://YOUR_DOMAIN/mcp` URL.
 
+## Render Deployment
+
+The default production target for this repository is Render, configured by `render.yaml` at the repository root.
+
+The Blueprint defines one Docker web service:
+
+- service name: `academic-writing-toolkit-chatgpt-app`
+- Dockerfile: `apps/chatgpt-academic-writing-toolkit/Dockerfile`
+- build context: repository root
+- plan: `starter`
+- region: `oregon`
+- health check: `/health`
+- deploy trigger: `checksPass`
+
+Why Render for the first public MCP endpoint:
+
+- Docker web services fit the existing Express MCP server without changing the app.
+- Render provides a public `onrender.com` HTTPS URL by default.
+- `checksPass` avoids deploying a commit before GitHub CI succeeds.
+- The `starter` plan avoids free-tier spin-down during app review.
+
+Setup:
+
+1. In Render, create a Blueprint from `https://github.com/yha9806/academic-writing-toolkit`.
+2. Confirm `render.yaml` is detected at the repository root.
+3. Create the service from the Blueprint.
+4. Wait for Render to deploy the `master` branch after checks pass.
+5. Copy the service URL, for example `https://academic-writing-toolkit-chatgpt-app.onrender.com`.
+6. Use `https://YOUR_RENDER_URL/mcp` as the MCP Server URL in OpenAI Platform Apps Manage.
+
+If OpenAI Platform asks for a domain challenge, set this environment variable on the Render service and redeploy:
+
+```sh
+OPENAI_APPS_CHALLENGE=<challenge value from OpenAI Platform>
+```
+
+Then verify:
+
+```sh
+curl -fsS https://YOUR_RENDER_URL/.well-known/openai-apps-challenge
+```
+
 ## Review Checklist
 
 Before pressing Submit for review:

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,18 @@
+services:
+  - type: web
+    name: academic-writing-toolkit-chatgpt-app
+    runtime: docker
+    plan: starter
+    region: oregon
+    branch: master
+    dockerfilePath: ./apps/chatgpt-academic-writing-toolkit/Dockerfile
+    dockerContext: .
+    autoDeployTrigger: checksPass
+    healthCheckPath: /health
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: HOST
+        value: 0.0.0.0
+      - key: PORT
+        value: "3000"


### PR DESCRIPTION
## Summary

- Add a root `render.yaml` Blueprint for the ChatGPT Apps MCP server as a Render Docker web service.
- Document the Render setup path, public HTTPS MCP URL to submit, health check, CI-gated deploy trigger, and OpenAI domain challenge verification.

## Validation

- `ruby -e 'require "yaml"; p YAML.load_file("render.yaml")'`
- `make chatgpt-app-check` (7/7 passing)
- `make test` (50/50 passing)
- Gemini diff review completed; its cautions were checked against current Render docs and existing server/tests.

## Notes

- Local Docker image build was not run because this Codex environment does not have the `docker` command installed.
- Render's current Blueprint docs define `autoDeployTrigger: checksPass`, and the app already serves `/health` plus `/.well-known/openai-apps-challenge` when `OPENAI_APPS_CHALLENGE` is configured.