### PR TITLE
[codex] Add release governance skill

### DIFF
--- a/.agents/skills/release-governance
+++ b/.agents/skills/release-governance
@@ -1,0 +1,1 @@
+../../.claude/skills/release-governance

--- a/.claude/skills/release-governance/SKILL.md
+++ b/.claude/skills/release-governance/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: release-governance
+description: Use when preparing, auditing, releasing, or rebuttal-hardening academic manuscripts, datasets, artifacts, reviewer packets, or claim registers involving multiple refs, local assets, human labels, or agent-assisted drafts.
+allowed-tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
+# /release-governance - Release Evidence Governance
+
+## Purpose
+
+Prepare release-facing academic artifacts with explicit evidence control. The core rule is:
+
+```text
+release truth = ref + artifact + gate
+```
+
+Do not infer release truth from memory, a branch name, a pull request title, a local file cache, or an agent draft.
+
+## Trigger Words
+
+This skill activates on: `release governance`, `release evidence`, `camera-ready`, `rebuttal packet`, `artifact packet`, `claim ledger`, `human evidence gate`, `release packet`, `/release-governance`.
+
+## Core Rules
+
+1. Name the exact ref, artifact, and gate behind every release-facing claim.
+2. Keep draft advisory evidence, verified artifacts, and final human evidence separate.
+3. Do not promote agent or Gemini review output into final evidence.
+4. Do not treat ignored, untracked, cached, or local-only assets as submitted artifacts.
+5. Do not treat a repository check as venue, submission-system, or scientific compliance.
+6. If two refs diverge, name both and scope which one is canonical for each artifact.
+7. If a worktree is dirty, list the dirty paths and mark the packet as draft until changes are committed or explicitly scoped.
+
+## Evidence States
+
+Use `references/evidence_state_schema.md` for the shared states:
+
+- `draft_advisory`
+- `verified_artifact`
+- `human_final`
+
+`human_final` requires an explicit human confirmation gate when the project schema provides one. Agent drafts, reviewer suggestions, generated summaries, simulations, and prefilled labels stay `draft_advisory`.
+
+## Workflow
+
+### 1. Declare Scope
+
+Create `release/release_scope.md` with scope date, artifact name, intended use, included refs, excluded refs, and the highest-risk open question.
+
+### 2. Map Repository Truth
+
+Run narrow ref checks before reading a checkout as final state:
+
+```bash
+git fetch --all --prune
+git status --short --branch
+git worktree list --porcelain
+git branch --all --verbose --no-abbrev
+```
+
+Create `release/canonical_refs.csv`. Detached HEADs are acceptable only when the exact SHA is recorded.
+
+### 3. Inventory Assets
+
+Create `release/local_asset_inventory.csv` to separate tracked, ignored, untracked, external-store, and generated assets. Local assets may support review, but release claims require an artifact anchor or explicit exclusion.
+
+### 4. Anchor Artifacts And Claims
+
+Create:
+
+- `release/artifact_anchors.csv`
+- `release/claim_ledger.csv`
+- `release/evidence_gates.csv`
+
+Every paper-facing number, qualitative conclusion, table value, figure, dataset count, and human-label claim should point to the artifact and gate that support it.
+
+### 5. Review Advisory Evidence
+
+Gemini or another agent may review the scope, packet, or diff, but its result is advisory. Record advisory review in the verification report without changing any evidence state to `human_final`.
+
+### 6. Verify Packet
+
+Use `references/release_workflow_templates.md` for columns and report structure. If Python is available, run:
+
+```bash
+python {skill_dir}/scripts/check_release_packet.py <project_root>
+```
+
+The helper checks required packet files, CSV/JSON/YAML readability, evidence-state values, required columns, local absolute paths, and obvious template markers. YAML files use PyYAML when installed; otherwise the helper applies a basic local syntax check for simple mappings and lists. It does not run experiments, access networks, push branches, or judge scientific validity.
+
+## Stop Conditions
+
+Stop and report a blocker if:
+
+- a final claim depends on a dirty or ambiguous ref
+- a human-label claim lacks a human confirmation gate
+- a release artifact exists only as an ignored, untracked, cache, or local-only file
+- a count comes from a pointer, stub, generated preview, or non-canonical ref
+- a draft pull request, closed-unmerged pull request, or advisory review is being treated as final release state
+- the packet validator reports issues that affect release-facing claims

--- a/.claude/skills/release-governance/references/evidence_state_schema.md
+++ b/.claude/skills/release-governance/references/evidence_state_schema.md
@@ -1,0 +1,39 @@
+# Release Evidence State Schema
+
+Release governance uses three states so agent-assisted drafts, verified files, and final human evidence stay visibly separate.
+
+| State | Meaning | Allowed use | Promotion gate |
+| --- | --- | --- | --- |
+| `draft_advisory` | Agent review, Gemini review, prefill output, simulation, draft label, reviewer note, or provisional working file. | Planning, triage, risk review, candidate wording, and follow-up tracking. | Cannot support final claims. Requires artifact verification or human confirmation before promotion. |
+| `verified_artifact` | A concrete file, count, checksum, manifest, figure, table, dataset slice, or export has been checked against an exact ref or named external artifact. | Artifact existence, provenance, counts, checksums, and bounded claims within the verified scope. | Requires a command, checksum, manifest, or manual artifact check recorded in the packet. |
+| `human_final` | A human reviewer, adjudicator, coordinator, or author has explicitly confirmed the evidence according to the project gate. | Human-label claims, adjudication conclusions, reviewer decisions, final wording approvals, and release sign-off. | Requires explicit human confirmation fields, reviewer identity or role, review date, and matching denominator or scope. |
+
+## Minimal Packet Schema
+
+Required files:
+
+- `release/release_scope.md`
+- `release/canonical_refs.csv`
+- `release/local_asset_inventory.csv`
+- `release/artifact_anchors.csv`
+- `release/evidence_gates.csv`
+- `release/claim_ledger.csv`
+- `release/verification_report.md`
+
+Required CSV columns:
+
+| File | Columns |
+| --- | --- |
+| `canonical_refs.csv` | `ref_name`, `sha`, `date`, `status`, `canonical_for`, `caveat` |
+| `local_asset_inventory.csv` | `path`, `status`, `file_count`, `size`, `role`, `release_action` |
+| `artifact_anchors.csv` | `artifact_id`, `source_ref`, `source_path`, `count_or_checksum`, `evidence_state`, `verified_by`, `claim_supported` |
+| `evidence_gates.csv` | `gate_id`, `artifact_id`, `evidence_state`, `human_confirmed`, `reviewer`, `review_date`, `validator`, `status` |
+| `claim_ledger.csv` | `claim_id`, `claim_text`, `artifact_ids`, `evidence_state`, `denominator`, `scope_boundary`, `human_gate_required`, `status` |
+
+## Gate Rules
+
+1. `draft_advisory` rows must not be described as final evidence.
+2. `verified_artifact` rows need an exact ref, artifact path, manifest, count, checksum, or recorded manual check.
+3. `human_final` rows need explicit confirmation, reviewer or coordinator identity, review date, and a denominator or scope boundary.
+4. Agent or Gemini review can flag risks, but it cannot promote any row to `human_final`.
+5. Repository checks prove repository state only; they do not prove venue, ethics, licensing, or scientific compliance.

--- a/.claude/skills/release-governance/references/release_workflow_templates.md
+++ b/.claude/skills/release-governance/references/release_workflow_templates.md
@@ -1,0 +1,107 @@
+# Release Workflow Templates
+
+These templates are intentionally file-driven. They are for manuscripts, datasets, review packets, artifact bundles, claim registers, rebuttal packages, and camera-ready checks.
+
+## Scope
+
+`release/release_scope.md`
+
+```text
+# Release Scope
+
+Scope date: 2026-05-31
+Paper/artifact: Generic review packet
+Deadline/use: collaborator handoff
+Included refs: refs/heads/main at abcdef1234567890
+Excluded refs: none
+Open question: whether an optional asset should stay local-only
+```
+
+## Canonical Refs
+
+`release/canonical_refs.csv`
+
+```text
+ref_name,sha,date,status,canonical_for,caveat
+main,abcdef1234567890,2026-05-31,clean,manuscript,none
+```
+
+## Local Asset Inventory
+
+`release/local_asset_inventory.csv`
+
+```text
+path,status,file_count,size,role,release_action
+figures/source/tracked.png,tracked,1,42K,figure source,keep tracked
+data/private-cache,ignored,120,80M,local review cache,exclude and document boundary
+```
+
+Allowed status values can be project-specific, but common values are `tracked`, `ignored`, `untracked`, `external-store`, and `generated`.
+
+## Artifact Anchors
+
+`release/artifact_anchors.csv`
+
+```text
+artifact_id,source_ref,source_path,count_or_checksum,evidence_state,verified_by,claim_supported
+fig1,main,figures/source/tracked.png,sha256:abc,verified_artifact,manual checksum,figure provenance
+```
+
+## Evidence Gates
+
+`release/evidence_gates.csv`
+
+```text
+gate_id,artifact_id,evidence_state,human_confirmed,reviewer,review_date,validator,status
+gate1,fig1,human_final,true,Reviewer One,2026-05-31,manual packet review,passed
+```
+
+Use `draft_advisory` for agent or Gemini reviews. Use `verified_artifact` for deterministic artifact checks. Use `human_final` only for explicit human confirmation.
+
+## Claim Ledger
+
+`release/claim_ledger.csv`
+
+```text
+claim_id,claim_text,artifact_ids,evidence_state,denominator,scope_boundary,human_gate_required,status
+c1,The figure is anchored to a tracked source artifact,fig1,verified_artifact,one figure,provenance only,false,supported
+```
+
+Check every row for:
+
+- stale denominators
+- subset-to-universe inflation
+- "final", "submitted", "merged", or "human" wording unsupported by the gate
+- local-only assets used as if they were release artifacts
+- advisory reviews used as final evidence
+
+## Verification Report
+
+`release/verification_report.md`
+
+```text
+# Verification Report
+
+Canonical refs:
+- main at abcdef1234567890 -> manuscript and tracked artifacts
+
+Advisory reviews:
+- Gemini scope review -> risks reviewed; no evidence-state promotion
+
+Verification:
+- python .claude/skills/release-governance/scripts/check_release_packet.py . -> clean
+- git diff --check -> clean
+
+Residual risk:
+- Optional external asset still needs owner decision before submission.
+```
+
+## Handoff Packet
+
+End release or rebuttal handoff with:
+
+| Item | Location | Ref/SHA | Owner | Next action |
+| --- | --- | --- | --- | --- |
+| Manuscript | `chapters/` or final export | exact SHA | author | final venue checklist |
+| Artifact manifest | `release/artifact_anchors.csv` | exact SHA | maintainer | checksum review |
+| Claim ledger | `release/claim_ledger.csv` | exact SHA | reviewer | approve or revise unsupported claims |

--- a/.claude/skills/release-governance/scripts/check_release_packet.py
+++ b/.claude/skills/release-governance/scripts/check_release_packet.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Lightweight validation for release-governance packets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+ALLOWED_EVIDENCE_STATES = {"draft_advisory", "verified_artifact", "human_final"}
+
+REQUIRED_FILES: Dict[str, Sequence[str]] = {
+    "release/release_scope.md": (),
+    "release/canonical_refs.csv": ("ref_name", "sha", "date", "status", "canonical_for", "caveat"),
+    "release/local_asset_inventory.csv": ("path", "status", "file_count", "size", "role", "release_action"),
+    "release/artifact_anchors.csv": (
+        "artifact_id",
+        "source_ref",
+        "source_path",
+        "count_or_checksum",
+        "evidence_state",
+        "verified_by",
+        "claim_supported",
+    ),
+    "release/evidence_gates.csv": (
+        "gate_id",
+        "artifact_id",
+        "evidence_state",
+        "human_confirmed",
+        "reviewer",
+        "review_date",
+        "validator",
+        "status",
+    ),
+    "release/claim_ledger.csv": (
+        "claim_id",
+        "claim_text",
+        "artifact_ids",
+        "evidence_state",
+        "denominator",
+        "scope_boundary",
+        "human_gate_required",
+        "status",
+    ),
+    "release/verification_report.md": (),
+}
+
+TEXT_EXTENSIONS = {".csv", ".json", ".md", ".txt", ".yaml", ".yml"}
+STRUCTURED_EXTENSIONS = {".csv", ".json", ".yaml", ".yml"}
+
+UNRESOLVED_CJK_MARKERS = "|".join((chr(0x5F85) + chr(0x8865), chr(0x5F85) + chr(0x5B9A)))
+MARKER_RE = re.compile(
+    r"\b(to\s*do|tbd|fix\s*me|xxx|replace me|fill in|pending update|placeholder|path/to|sample only)\b|"
+    + UNRESOLVED_CJK_MARKERS,
+    re.IGNORECASE,
+)
+LOCAL_PATH_RE = re.compile(
+    r"(^|[\s'\"(,;:])((/[Uu]sers|/[Hh]ome|/[Pp]rivate|/[Tt]mp|/[Vv]ar/[Ff]olders)(/|\b)|[A-Za-z]:\\)"
+)
+
+
+def issue(kind: str, path: str, detail: str, line: Optional[int] = None) -> Dict[str, object]:
+    item: Dict[str, object] = {"kind": kind, "path": path, "detail": detail}
+    if line is not None:
+        item["line"] = line
+    return item
+
+
+def iter_packet_files(root: Path) -> Iterable[Path]:
+    release_dir = root / "release"
+    if not release_dir.is_dir():
+        return []
+    return (path for path in sorted(release_dir.rglob("*")) if path.is_file())
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def check_text(path: Path, rel: str) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    if path.suffix.lower() not in TEXT_EXTENSIONS:
+        return issues
+    try:
+        text = read_text(path)
+    except UnicodeDecodeError as exc:
+        return [issue("decode-error", rel, str(exc))]
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if MARKER_RE.search(line):
+            issues.append(issue("placeholder-text", rel, "remove unresolved template marker or working note", line_no))
+        if LOCAL_PATH_RE.search(line):
+            issues.append(issue("local-absolute-path", rel, "replace local absolute path with a relative path or external artifact identifier", line_no))
+    return issues
+
+
+def read_csv(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+    if reader.fieldnames is None:
+        raise ValueError("no header row")
+    return list(reader.fieldnames), rows
+
+
+def parse_yaml_fallback(text: str) -> None:
+    stack = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("- "):
+            stack.append(line)
+            continue
+        if ":" not in line:
+            raise ValueError("line is not a simple yaml mapping or list item")
+
+
+def parse_structured(path: Path) -> None:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        read_csv(path)
+    elif suffix == ".json":
+        json.loads(read_text(path))
+    elif suffix in {".yaml", ".yml"}:
+        text = read_text(path)
+        try:
+            import yaml  # type: ignore
+        except Exception:
+            parse_yaml_fallback(text)
+        else:
+            yaml.safe_load(text)
+
+
+def check_required_file(root: Path, rel: str, columns: Sequence[str]) -> List[Dict[str, object]]:
+    path = root / rel
+    if not path.exists():
+        return [issue("missing-file", rel, "required release packet file is missing")]
+    if not path.is_file():
+        return [issue("not-file", rel, "required path is not a file")]
+    if path.suffix.lower() != ".csv":
+        return []
+    try:
+        fieldnames, rows = read_csv(path)
+    except Exception as exc:
+        return [issue("csv-parse-error", rel, str(exc))]
+    missing = [column for column in columns if column not in fieldnames]
+    issues: List[Dict[str, object]] = []
+    if missing:
+        issues.append(issue("missing-columns", rel, ", ".join(missing)))
+    issues.extend(check_evidence_states(rel, rows))
+    issues.extend(check_human_final_gate(rel, rows))
+    return issues
+
+
+def check_evidence_states(rel: str, rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    for index, row in enumerate(rows, start=2):
+        value = (row.get("evidence_state") or "").strip()
+        if value and value not in ALLOWED_EVIDENCE_STATES:
+            issues.append(issue("invalid-evidence-state", rel, value, index))
+    return issues
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"true", "yes", "y", "1", "confirmed", "passed"}
+
+
+def check_human_final_gate(rel: str, rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    for index, row in enumerate(rows, start=2):
+        if (row.get("evidence_state") or "").strip() != "human_final":
+            continue
+        if "human_confirmed" in row and not truthy(row.get("human_confirmed", "")):
+            issues.append(issue("human-final-gate-missing", rel, "human_final row needs human_confirmed=true", index))
+        if "reviewer" in row and not row.get("reviewer", "").strip():
+            issues.append(issue("human-final-gate-missing", rel, "human_final row needs reviewer", index))
+        if "review_date" in row and not row.get("review_date", "").strip():
+            issues.append(issue("human-final-gate-missing", rel, "human_final row needs review_date", index))
+    return issues
+
+
+def validate(root: Path) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    release_dir = root / "release"
+    if not release_dir.is_dir():
+        issues.append(issue("missing-directory", "release", "release packet directory is missing"))
+
+    for rel, columns in REQUIRED_FILES.items():
+        issues.extend(check_required_file(root, rel, columns))
+
+    for path in iter_packet_files(root):
+        rel = path.relative_to(root).as_posix()
+        issues.extend(check_text(path, rel))
+        if path.suffix.lower() in STRUCTURED_EXTENSIONS:
+            try:
+                parse_structured(path)
+            except Exception as exc:
+                issues.append(issue("parse-error", rel, str(exc)))
+    return issues
+
+
+def emit_text(root: Path, issues: List[Dict[str, object]]) -> None:
+    print("Release packet root: {}".format(root))
+    if not issues:
+        print("- no release packet issues detected")
+        return
+    print("- issues: {}".format(len(issues)))
+    for item in issues:
+        location = item["path"]
+        if "line" in item:
+            location = "{}:{}".format(location, item["line"])
+        print("- {kind}: {location}: {detail}".format(location=location, **item))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a release-governance packet.")
+    parser.add_argument("root", nargs="?", default=".", help="project root containing release/")
+    parser.add_argument("--json", action="store_true", dest="emit_json", help="emit machine-readable output")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        sys.stderr.write("error: root is not a directory\n")
+        return 2
+
+    issues = validate(root)
+    payload = {
+        "schema_version": 1,
+        "root": str(root),
+        "issues": issues,
+        "issue_count": len(issues),
+        "allowed_evidence_states": sorted(ALLOWED_EVIDENCE_STATES),
+    }
+    if args.emit_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        emit_text(root, issues)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # academic-writing-toolkit
 
-Structured local agent skills for academic reading, writing, reference checking, and export.
+agent-native, local-first workflows for evidence-controlled literature review, thesis writing, citation auditing, reference verification, and release governance.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-Standard-blue.svg)](https://agentskills.io)
 
-This repository is a public toolkit. It contains reusable local agent skills, scripts, templates, and tests only. Put your own chapters, PDFs, notes, and private project material in your clone.
+Academic Writing Toolkit is a public toolkit for researchers who want their local AI agent to work through academic writing tasks with repeatable files, checks, and evidence controls. Install it into a writing project, open that project in Codex, Claude Code, Gemini CLI, Cursor, or another compatible agent host, and use the skills as a structured research workflow.
 
-The repository also includes distribution packaging for a Codex plugin and a tool-only ChatGPT App MCP server.
+This is not a SaaS product and it does not host your thesis. Your chapters, PDFs, reading notes, evidence registers, release packets, and exports stay in your clone.
 
 ## Product Surfaces
 
@@ -16,6 +16,28 @@ Local agent skills are the full workflow. Use them when an agent can read and wr
 The Codex plugin packages those same local skills for Codex plugin installation. It is a distribution surface, not a separate workflow.
 
 The ChatGPT App MCP server is narrower. It provides pasted-text checks and template generation through temporary files only; it does not read or write a local thesis project, run the full skill pipeline, or persist user submissions.
+
+## 10-minute demo
+
+Inspect the runnable demo project:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+Then open [`examples/demo-project/`](examples/demo-project/) in your agent host and ask it to explain the local workflow.
+
+## Common use cases
+
+- [Write a literature review](docs/use-cases/write-literature-review.md)
+- [Audit thesis citations](docs/use-cases/audit-thesis-citations.md)
+- [Verify references before submission](docs/use-cases/verify-references-before-submission.md)
+- [Prepare a release-governance packet](docs/use-cases/prepare-release-governance-packet.md)
+- [Choose the right product surface](docs/use-cases/choose-product-surface.md)
+
+## Workflow
 
 ```
 /read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /release-governance -> /style -> /logic-review -> /export
@@ -72,6 +94,8 @@ Setup guides live in [`docs/setup-claude-code.md`](docs/setup-claude-code.md), [
 | `/export` | Convert Markdown outputs to `.docx` and ZIP packages |
 
 Detailed guides live in [`docs/skills/`](docs/skills/).
+
+The local agent skill guides are organized by command name; goal-oriented guides live in [`docs/use-cases/`](docs/use-cases/).
 
 ## Quality Checks
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ agent-native, local-first workflows for evidence-controlled literature review, t
 
 Academic Writing Toolkit is a public toolkit for researchers who want their local AI agent to work through academic writing tasks with repeatable files, checks, and evidence controls. Install it into a writing project, open that project in Codex, Claude Code, Gemini CLI, Cursor, or another compatible agent host, and use the skills as a structured research workflow.
 
-This is not a SaaS product and it does not host your thesis. Your chapters, PDFs, reading notes, evidence registers, release packets, and exports stay in your clone.
+This is not a SaaS product and it does not host your thesis. Your chapters, PDFs, reading notes, evidence registers, release packets, and exports stay in your clone. Optional reference metadata checks use external APIs only when you explicitly run them with `--online`.
 
 ## Product Surfaces
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is a public toolkit. It contains reusable local agent skills, sc
 The repository also includes distribution packaging for a Codex plugin and a tool-only ChatGPT App MCP server.
 
 ```
-/read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /style -> /logic-review -> /export
+/read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /release-governance -> /style -> /logic-review -> /export
              |                                      |
              v                                      v
         /verify                               /verify-refs
@@ -56,6 +56,7 @@ Setup guides live in [`docs/setup-claude-code.md`](docs/setup-claude-code.md), [
 | `/evidence-review` | Build evidence-controlled gap maps, claim registers, citation plans, and overclaim audits |
 | `/integrate` | Propose and apply approved note-to-chapter integrations |
 | `/audit` | Check numbers, terminology, cross-references, and citations |
+| `/release-governance` | Prepare release, rebuttal, artifact, and claim packets with ref-artifact-gate controls |
 | `/style` | Check and safely fix British English spellings |
 | `/logic-review` | Review paragraph flow, transitions, and argument continuity |
 | `/verify-refs` | Validate BibTeX records offline or with explicit metadata checks |
@@ -80,9 +81,12 @@ python3 scripts/audit-logic.py --base-dir . --json
 python3 scripts/verify-refs.py --bib references.bib --json
 python3 scripts/verify-refs.py --bib references.bib --json --online
 python3 scripts/verify-refs.py --bib references.bib --json --online --metadata-dir path/to/metadata-fixtures
+
+python3 .claude/skills/release-governance/scripts/check_release_packet.py .
 ```
 
 Safe fixers are intentionally narrow. Citation fixes only apply conservative formatting changes such as Harvard comma normalisation; British English fixes only apply whole-word spelling replacements from the built-in map. Paragraph logic and reference metadata checks report findings for agent or user review.
+Release packet checks are also narrow: they validate files, columns, evidence-state values, parseability, local path leakage, and unresolved template markers, but they do not judge scientific validity or venue compliance.
 
 ## Project Layout
 
@@ -96,6 +100,7 @@ my-writing-project/
 ├── literature/
 │   └── reading_notes/       One notes file per source
 ├── plugins/                 Codex plugin package
+├── release/                 Optional release governance packets
 ├── final_output/            Exported documents
 ├── scripts/                 Deterministic helper checks
 ├── CLAUDE.md                Canonical project configuration

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ make plugin-check  # validate plugin metadata, sync state, and bundled helpers
 make chatgpt-app-check  # run the ChatGPT App MCP server checks
 ```
 
-For Codex plugin release preparation, use [`docs/plugin-publishing-checklist.md`](docs/plugin-publishing-checklist.md). For ChatGPT App deployment and submission preparation, use [`docs/chatgpt-app-publishing.md`](docs/chatgpt-app-publishing.md).
+For Codex plugin release preparation, use [`docs/plugin-publishing-checklist.md`](docs/plugin-publishing-checklist.md). For ChatGPT App deployment and submission preparation, use [`docs/chatgpt-app-publishing.md`](docs/chatgpt-app-publishing.md). For `v0.3.0` release preparation, use [`docs/product/v0.3.0-release-readiness.md`](docs/product/v0.3.0-release-readiness.md).
 
 The regression suite covers local skill discovery, config sync, export assumptions, citation auditing, public-content cleanup, British English checks, paragraph-logic checks, and offline plus fixture-backed reference verification.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This repository is a public toolkit. It contains reusable local agent skills, sc
 
 The repository also includes distribution packaging for a Codex plugin and a tool-only ChatGPT App MCP server.
 
+## Product Surfaces
+
+Local agent skills are the full workflow. Use them when an agent can read and write the project files in your clone: chapters, reading notes, evidence registers, release packets, and export outputs.
+
+The Codex plugin packages those same local skills for Codex plugin installation. It is a distribution surface, not a separate workflow.
+
+The ChatGPT App MCP server is narrower. It provides pasted-text checks and template generation through temporary files only; it does not read or write a local thesis project, run the full skill pipeline, or persist user submissions.
+
 ```
 /read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /release-governance -> /style -> /logic-review -> /export
              |                                      |

--- a/docs/product/agent-native-productization-design.md
+++ b/docs/product/agent-native-productization-design.md
@@ -1,0 +1,187 @@
+# Agent-Native Productization Design
+
+## Goal
+
+Turn Academic Writing Toolkit from a capable repository of agent skills into a product that a new researcher can understand, install, and validate in one short session.
+
+The first productization pass should make the project feel like an agent-native academic workflow product, not a loose collection of scripts, and should prepare the current release-governance work for a coherent `v0.3.0` release.
+
+## Product Positioning
+
+Academic Writing Toolkit is an agent-native, local-first skill pack for evidence-controlled academic writing workflows.
+
+It is not a standalone SaaS application. Codex, Claude Code, Gemini CLI, Cursor, and compatible local agents are execution hosts. The toolkit provides the domain workflow, deterministic checks, schemas, templates, and repeatable project structure those agents use.
+
+The product should be described as:
+
+> A local-first agent skill pack for evidence-controlled literature review, thesis writing, citation auditing, reference verification, and release governance.
+
+## Current Problem
+
+The repository has a strong technical core:
+
+- local agent skills for reading, note-taking, mapping, evidence review, integration, audit, release governance, style review, logic review, reference verification, progress, and export
+- deterministic scripts and tests for several high-risk checks
+- distribution surfaces for local skills, Codex plugin packaging, and a narrow ChatGPT App MCP server
+
+The product gap is first-use clarity. A user can see that many capabilities exist, but they do not yet get a compact, guided path from clone to successful academic workflow output. This creates three risks:
+
+- Interested users star the repository but do not become active users.
+- Users confuse the local skill workflow, Codex plugin, and ChatGPT App MCP server.
+- Release-governance looks like another skill rather than the closing step of an evidence-controlled workflow.
+
+## Reference Products
+
+The product should borrow patterns from adjacent tools without copying their product model.
+
+| Reference | Useful Pattern | Toolkit Adaptation |
+|-----------|----------------|--------------------|
+| PaperQA2 | Local document search, grounded answers, source-aware workflow | Later: optional library Q&A. Now: emphasise local-first evidence control and source-backed outputs. |
+| Elicit systematic reviews | Protocol, screening, extraction, synthesis, PRISMA-style audit trail | Later: screening packet. Now: make evidence-review outputs understandable as auditable review materials. |
+| Rayyan | Clear systematic-review screening workflow and collaboration vocabulary | Later: include/exclude decision register. Now: use workflow-oriented docs instead of skill-only docs. |
+| ASReview | Open-source, user-controlled, transparent AI-aided review process | Reinforce local-first, transparent files, deterministic checks, and no hidden data persistence. |
+| Zotero | Researchers already start from a library and citation workflow | Later: Zotero import bridge. Now: document where reference verification fits beside existing reference managers. |
+| Semantic Scholar | Research feeds and paper discovery | Later: candidate-paper queue. Now: avoid making discovery promises before the local workflow is strong. |
+| GPT Researcher | One-command research report and citation-oriented output | Later: guided report generation. Now: provide a demo project and concrete output examples. |
+
+## Product Surfaces
+
+The public product should keep three surfaces distinct:
+
+1. **Local agent skills** are the full product. They work when an agent can read and write the project folder.
+2. **Codex plugin** is an installable distribution wrapper for the same local skills.
+3. **ChatGPT App MCP server** is a narrower pasted-text tool surface. It should not be marketed as the full local thesis workflow.
+
+This boundary should remain prominent in README and onboarding docs.
+
+## P0 Productization Pack
+
+The first implementation should be documentation- and example-focused.
+
+### 1. README Positioning Rewrite
+
+The README should lead with the product promise, then show the workflow and quickest path to a first result.
+
+The top of the README should answer:
+
+- What is this?
+- Who is it for?
+- Where does it run?
+- What can I complete in 10 minutes?
+- Which surface should I use: local skills, Codex plugin, or ChatGPT App?
+
+### 2. Guided Demo Project
+
+Add a small `examples/demo-project/` that a user can inspect and run without private data.
+
+The demo should include:
+
+- `CLAUDE.md`, `AGENTS.md`, and `GEMINI.md` style project config where appropriate
+- one short sample chapter
+- two or three generic reading notes
+- a small BibTeX file
+- an evidence-review packet sample
+- a release-governance packet sample
+- expected outputs documented in a README
+
+The demo should avoid real private thesis material and avoid project-specific research claims. It should use generic fictional or public-domain-style examples.
+
+### 3. Use-Case Guides
+
+Add a small docs layer organized by user goals, not by skill internals:
+
+- `docs/use-cases/write-literature-review.md`
+- `docs/use-cases/audit-thesis-citations.md`
+- `docs/use-cases/verify-references-before-submission.md`
+- `docs/use-cases/prepare-release-governance-packet.md`
+- `docs/use-cases/choose-product-surface.md`
+
+These guides should link back to the canonical skill docs rather than duplicating all skill details.
+
+### 4. Release Readiness For v0.3.0
+
+PR #14 should be treated as the release candidate for `v0.3.0` after this productization pass lands.
+
+The release should highlight:
+
+- release-governance skill
+- evidence-review positioning
+- local agent documentation consistency
+- verify-refs public migration guard
+- demo project and use-case docs
+
+The release checklist should verify:
+
+- `make test`
+- `make plugin-check`
+- `make chatgpt-app-check`
+- public-content audit
+- plugin packaging state
+- README and demo links
+
+## Future Product Tracks
+
+These are deliberately out of scope for P0, but they should guide the roadmap.
+
+### Zotero Bridge
+
+Support importing a Zotero-exported BibTeX or RIS file into toolkit scaffolds:
+
+- reference verification input
+- reading note templates
+- source map starter
+- evidence-review candidate source list
+
+Avoid reading Zotero SQLite directly in the first version. Export-file import is safer and easier to document.
+
+### Systematic Review Screening Packet
+
+Add a local file-based workflow for screening:
+
+- protocol criteria
+- candidate records
+- include/exclude decisions
+- exclusion reasons
+- conflict status
+- PRISMA-lite counts
+
+This should borrow from Elicit, Rayyan, and ASReview while staying local and auditable.
+
+### Library Q&A
+
+Optionally integrate with a local document index for source-backed Q&A. This should come after the demo and use-case docs because RAG adds dependency and expectation risk.
+
+## Files In Scope For P0
+
+- `README.md`
+- `docs/use-cases/`
+- `examples/demo-project/`
+- `docs/skills/README.md`, only for cross-links
+- `docs/plugin-publishing-checklist.md`, only if release notes need a pointer
+- `docs/chatgpt-app-publishing.md`, only if surface boundaries need clarification
+- `scripts/test.sh`, only for lightweight guards around demo/public docs
+
+## Files Out Of Scope For P0
+
+- new runtime dependencies
+- Zotero API or SQLite integration
+- PDF parsing engine changes
+- RAG or vector search
+- hosted SaaS surfaces
+- ChatGPT App expansion to local project access
+- major skill behaviour changes
+
+## Acceptance Criteria
+
+1. A new user can read the README and understand that the product is an agent-native local workflow, not a SaaS.
+2. A new user can inspect `examples/demo-project/` and understand what a successful workflow output looks like.
+3. Use-case docs explain common goals without duplicating all skill implementation details.
+4. The local skills, Codex plugin, and ChatGPT App surfaces remain clearly separated.
+5. The release-governance PR has a clear path to `v0.3.0`.
+6. Public-content and test checks prevent private or project-specific material from entering the demo or docs.
+
+## Risks
+
+The main risk is over-expanding productization into feature development. Keep P0 focused on positioning, onboarding, examples, and release readiness. Zotero, systematic-review screening, and library Q&A are valuable, but they should be separate design and implementation cycles.
+
+Another risk is over-promising evidence control. Documentation should state that deterministic scripts and release packet checks improve auditability, but they do not replace human academic judgement.

--- a/docs/product/agent-native-productization-implementation-plan.md
+++ b/docs/product/agent-native-productization-implementation-plan.md
@@ -1,0 +1,973 @@
+# Agent-Native Productization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the P0 productization pack: clearer agent-native positioning, a runnable demo project, use-case docs, and `v0.3.0` release-readiness guidance.
+
+**Architecture:** Keep the core product local-first and host-agnostic. Do not add runtime dependencies or new skill behaviour; use existing deterministic scripts to validate the demo and keep public docs from drifting into unsupported claims.
+
+**Tech Stack:** Markdown docs, Bash regression harness in `scripts/test.sh`, existing Python validators for references, evidence-review packages, and release-governance packets.
+
+---
+
+## File Structure
+
+- `README.md`: human-facing product entry point, surface chooser, 10-minute demo path, and use-case links.
+- `examples/demo-project/`: safe generic project fixture that demonstrates the local workflow.
+- `examples/demo-project/README.md`: demo explanation and exact validation commands.
+- `examples/demo-project/CLAUDE.md`: demo project configuration for Claude Code.
+- `examples/demo-project/AGENTS.md`: demo project instructions for Codex and compatible agents.
+- `examples/demo-project/GEMINI.md`: demo project instructions for Gemini CLI.
+- `examples/demo-project/chapters/ch01.md`: short chapter draft with generic citations.
+- `examples/demo-project/literature/reading_notes/*.md`: two generic reading-note files.
+- `examples/demo-project/references.bib`: offline-valid BibTeX for the demo.
+- `examples/demo-project/evidence/*.csv`: evidence-review package validated by `check_review_package.py`.
+- `examples/demo-project/release/*`: release-governance packet validated by `check_release_packet.py`.
+- `docs/use-cases/README.md`: index for goal-oriented product guides.
+- `docs/use-cases/write-literature-review.md`: local literature-review workflow guide.
+- `docs/use-cases/audit-thesis-citations.md`: citation/style/logic audit workflow guide.
+- `docs/use-cases/verify-references-before-submission.md`: reference verification workflow guide.
+- `docs/use-cases/prepare-release-governance-packet.md`: release packet workflow guide.
+- `docs/use-cases/choose-product-surface.md`: local skills versus Codex plugin versus ChatGPT App guidance.
+- `docs/skills/README.md`: add a short cross-link to use-case docs without duplicating skill details.
+- `docs/product/v0.3.0-release-readiness.md`: release checklist for the productization pass and PR #14.
+- `scripts/test.sh`: add focused productization regression tests T61-T63.
+
+## Execution Boundaries
+
+Do not add new runtime dependencies in this pass. Do not implement Zotero import, RAG, vector search, hosted SaaS surfaces, or ChatGPT App access to local project files. If implementation pressure appears in any of those directions, stop and write a separate design first.
+
+## Task 1: Add Productization Regression Tests
+
+**Files:**
+- Modify: `scripts/test.sh`
+
+- [ ] **Step 1: Add failing structure and positioning test**
+
+Insert this function after `test_T60()`:
+
+```bash
+test_T61() {
+    local demo="$REPO_ROOT/examples/demo-project"
+    local use_cases="$REPO_ROOT/docs/use-cases"
+
+    [[ -f "$demo/README.md" ]] || return 1
+    [[ -f "$demo/CLAUDE.md" ]] || return 1
+    [[ -f "$demo/AGENTS.md" ]] || return 1
+    [[ -f "$demo/GEMINI.md" ]] || return 1
+    [[ -f "$demo/chapters/ch01.md" ]] || return 1
+    [[ -f "$demo/literature/reading_notes/smith2024_NOTES.md" ]] || return 1
+    [[ -f "$demo/literature/reading_notes/jones2023_NOTES.md" ]] || return 1
+    [[ -f "$demo/references.bib" ]] || return 1
+
+    [[ -f "$use_cases/README.md" ]] || return 1
+    [[ -f "$use_cases/write-literature-review.md" ]] || return 1
+    [[ -f "$use_cases/audit-thesis-citations.md" ]] || return 1
+    [[ -f "$use_cases/verify-references-before-submission.md" ]] || return 1
+    [[ -f "$use_cases/prepare-release-governance-packet.md" ]] || return 1
+    [[ -f "$use_cases/choose-product-surface.md" ]] || return 1
+
+    grep -q "agent-native" "$REPO_ROOT/README.md" || return 1
+    grep -q "local-first" "$REPO_ROOT/README.md" || return 1
+    grep -q "10-minute demo" "$REPO_ROOT/README.md" || return 1
+    grep -q "docs/use-cases" "$REPO_ROOT/README.md" || return 1
+    grep -q "examples/demo-project" "$REPO_ROOT/README.md" || return 1
+}
+```
+
+- [ ] **Step 2: Add failing demo validation test**
+
+Insert this function after `test_T61()`:
+
+```bash
+test_T62() {
+    local demo="$REPO_ROOT/examples/demo-project"
+    local out
+
+    python3 scripts/verify-refs.py --bib "$demo/references.bib" --json >/dev/null || return 1
+    python3 .claude/skills/evidence-review/scripts/check_review_package.py "$demo" --strict >/dev/null || return 1
+    out=$(python3 .claude/skills/release-governance/scripts/check_release_packet.py "$demo" --json) || return 1
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['issue_count'] == 0"
+}
+```
+
+- [ ] **Step 3: Add failing local-link and public-path guard**
+
+Insert this function after `test_T62()`:
+
+```bash
+test_T63() {
+    python3 - "$REPO_ROOT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+files = [
+    root / "README.md",
+    root / "docs/use-cases/README.md",
+    root / "docs/use-cases/write-literature-review.md",
+    root / "docs/use-cases/audit-thesis-citations.md",
+    root / "docs/use-cases/verify-references-before-submission.md",
+    root / "docs/use-cases/prepare-release-governance-packet.md",
+    root / "docs/use-cases/choose-product-surface.md",
+    root / "examples/demo-project/README.md",
+]
+pattern = re.compile(r"!?\[[^\]]+\]\(([^)]+)\)")
+missing = []
+for path in files:
+    if not path.is_file():
+        missing.append(str(path.relative_to(root)))
+        continue
+    text = path.read_text(encoding="utf-8")
+    for match in pattern.finditer(text):
+        target = match.group(1).strip()
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        target = target.split("#", 1)[0]
+        if not target:
+            continue
+        candidate = (path.parent / target).resolve()
+        if not str(candidate).startswith(str(root.resolve())) or not candidate.exists():
+            missing.append(f"{path.relative_to(root)} -> {target}")
+if missing:
+    raise SystemExit("\n".join(missing))
+PY
+}
+```
+
+- [ ] **Step 4: Register the tests**
+
+Add these run lines after the T60 run line:
+
+```bash
+run_test "T61 productization docs and demo structure exist" test_T61
+run_test "T62 demo project validates with existing checkers" test_T62
+run_test "T63 productization docs keep local links valid" test_T63
+```
+
+Update the header comment from:
+
+```bash
+# scripts/test.sh — runs the regression test suite (57 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX) for academic-writing-toolkit.
+```
+
+to:
+
+```bash
+# scripts/test.sh — runs the regression test suite (60 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX + T61-T63 productization) for academic-writing-toolkit.
+```
+
+- [ ] **Step 5: Verify red**
+
+Run:
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: the suite fails at T61, T62, and T63 because the productization docs and demo files do not exist yet.
+
+- [ ] **Step 6: Commit failing tests**
+
+Run:
+
+```bash
+git add scripts/test.sh
+git commit -m "test: add productization regression guards"
+```
+
+Expected: commit succeeds with only `scripts/test.sh` staged.
+
+## Task 2: Rewrite README Positioning And Onboarding
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README opening**
+
+Replace the opening description through the current `Product Surfaces` section with:
+
+```markdown
+# academic-writing-toolkit
+
+Agent-native, local-first workflows for evidence-controlled literature review, thesis writing, citation auditing, reference verification, and release governance.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Agent Skills](https://img.shields.io/badge/Agent_Skills-Standard-blue.svg)](https://agentskills.io)
+
+Academic Writing Toolkit is a public toolkit for researchers who want their local AI agent to work through academic writing tasks with repeatable files, checks, and evidence controls. Install it into a writing project, open that project in Codex, Claude Code, Gemini CLI, Cursor, or another compatible agent host, and use the skills as a structured research workflow.
+
+This is not a SaaS product and it does not host your thesis. Your chapters, PDFs, reading notes, evidence registers, release packets, and exports stay in your clone.
+
+## Product Surfaces
+
+Local agent skills are the full workflow. Use them when an agent can read and write the project files in your clone: chapters, reading notes, evidence registers, release packets, and export outputs.
+
+The Codex plugin packages those same local skills for Codex plugin installation. It is a distribution surface, not a separate workflow.
+
+The ChatGPT App MCP server is narrower. It provides pasted-text checks and template generation through temporary files only; it does not read or write a local thesis project, run the full skill pipeline, or persist user submissions.
+
+## 10-minute demo
+
+Inspect the runnable demo project:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+Then open [`examples/demo-project/`](examples/demo-project/) in your agent host and ask it to explain the local workflow.
+
+## Common use cases
+
+- [Write a literature review](docs/use-cases/write-literature-review.md)
+- [Audit thesis citations](docs/use-cases/audit-thesis-citations.md)
+- [Verify references before submission](docs/use-cases/verify-references-before-submission.md)
+- [Prepare a release-governance packet](docs/use-cases/prepare-release-governance-packet.md)
+- [Choose the right product surface](docs/use-cases/choose-product-surface.md)
+```
+
+- [ ] **Step 2: Preserve the workflow diagram**
+
+Move the existing pipeline diagram so it remains immediately after the new `Common use cases` section:
+
+```markdown
+## Workflow
+
+```text
+/read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /release-governance -> /style -> /logic-review -> /export
+             |                                      |
+             v                                      v
+        /verify                               /verify-refs
+             |
+             v
+        /progress
+```
+```
+
+- [ ] **Step 3: Verify README content**
+
+Run:
+
+```bash
+rg -n "agent-native|local-first|10-minute demo|docs/use-cases|examples/demo-project" README.md
+```
+
+Expected: each phrase appears in the README.
+
+- [ ] **Step 4: Run targeted test**
+
+Run:
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: T61 still fails because demo and use-case files do not exist. README-related assertions in T61 should be satisfied.
+
+- [ ] **Step 5: Commit README positioning**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: clarify agent native product positioning"
+```
+
+Expected: commit succeeds with only `README.md` staged.
+
+## Task 3: Create Runnable Demo Project
+
+**Files:**
+- Create: `examples/demo-project/README.md`
+- Create: `examples/demo-project/CLAUDE.md`
+- Create: `examples/demo-project/AGENTS.md`
+- Create: `examples/demo-project/GEMINI.md`
+- Create: `examples/demo-project/chapters/ch01.md`
+- Create: `examples/demo-project/literature/reading_notes/smith2024_NOTES.md`
+- Create: `examples/demo-project/literature/reading_notes/jones2023_NOTES.md`
+- Create: `examples/demo-project/references.bib`
+- Create: `examples/demo-project/docs/review_protocol.md`
+- Create: `examples/demo-project/evidence/evidence_matrix.csv`
+- Create: `examples/demo-project/evidence/claim_register.csv`
+- Create: `examples/demo-project/evidence/citation_plan.csv`
+- Create: `examples/demo-project/evidence/overclaim_risk_register.csv`
+- Create: `examples/demo-project/reports/review_summary.md`
+- Create: `examples/demo-project/summaries/source_summary.md`
+- Create: `examples/demo-project/release/release_scope.md`
+- Create: `examples/demo-project/release/canonical_refs.csv`
+- Create: `examples/demo-project/release/local_asset_inventory.csv`
+- Create: `examples/demo-project/release/artifact_anchors.csv`
+- Create: `examples/demo-project/release/evidence_gates.csv`
+- Create: `examples/demo-project/release/claim_ledger.csv`
+- Create: `examples/demo-project/release/verification_report.md`
+
+- [ ] **Step 1: Create demo README**
+
+Create `examples/demo-project/README.md`:
+
+```markdown
+# Demo Project
+
+This demo shows the local Academic Writing Toolkit workflow without private research material.
+
+Run these commands from the repository root:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+The demo includes:
+
+- a short chapter draft in [`chapters/ch01.md`](chapters/ch01.md)
+- two reading notes in [`literature/reading_notes/`](literature/reading_notes/)
+- a BibTeX file in [`references.bib`](references.bib)
+- an evidence-review packet in [`evidence/`](evidence/)
+- a release-governance packet in [`release/`](release/)
+
+Open this folder in Codex, Claude Code, Gemini CLI, Cursor, or another compatible local agent and ask:
+
+```text
+Explain how this demo project moves from reading notes to evidence review and release governance.
+```
+```
+
+- [ ] **Step 2: Create demo agent config files**
+
+Create `examples/demo-project/CLAUDE.md`:
+
+```markdown
+# Demo Academic Writing Project
+
+This is a public demo for Academic Writing Toolkit. It uses fictional source records and generic claims.
+
+## Directories
+
+- Chapters: `chapters/`
+- Literature notes: `literature/reading_notes/`
+- Evidence review packet: `evidence/`
+- Release packet: `release/`
+
+## Writing Principles
+
+- Keep claims tied to reading notes.
+- Use British English in chapter prose.
+- Treat release packet checks as auditability checks, not human academic approval.
+```
+
+Create `examples/demo-project/AGENTS.md`:
+
+```markdown
+# Demo Academic Writing Project
+
+Follow `CLAUDE.md` for the demo workflow. Use the repository-level Academic Writing Toolkit skills when available.
+
+## Checks
+
+Run these from the repository root when validating the demo:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+```
+
+Create `examples/demo-project/GEMINI.md`:
+
+```markdown
+# Demo Academic Writing Project
+
+This demo mirrors the local agent workflow described in `CLAUDE.md`.
+
+Use it to explain or inspect the workflow. Do not treat the fictional sources as real scholarship.
+```
+
+- [ ] **Step 3: Create chapter and reading notes**
+
+Create `examples/demo-project/chapters/ch01.md`:
+
+```markdown
+# Chapter 1: Local-first Review Workflow
+
+Local-first academic writing workflows benefit from separating source notes, evidence claims, and release checks (Smith 2024; Jones 2023).
+
+Smith (2024) describes a file-based workflow where notes and claims remain inspectable. Jones (2023) focuses on review audit trails and argues that explicit decision records make later synthesis easier to check.
+```
+
+Create `examples/demo-project/literature/reading_notes/smith2024_NOTES.md`:
+
+```markdown
+# Smith 2024 Notes
+
+**Status**: complete
+**Source**: Smith, Jane (2024). Local-first research workflows. Journal of Research Tooling.
+
+## Relevance
+
+Supports the demo claim that local files can keep notes and claims inspectable.
+
+## Detailed Notes
+
+- The article describes storing source notes beside draft materials.
+- The article treats auditability as a workflow property.
+
+## Thesis Connections
+
+- Use in the introduction to explain why local-first workflows matter.
+```
+
+Create `examples/demo-project/literature/reading_notes/jones2023_NOTES.md`:
+
+```markdown
+# Jones 2023 Notes
+
+**Status**: complete
+**Source**: Jones, Alex (2023). Review audit trails for research teams. Proceedings of Demo Methods.
+
+## Relevance
+
+Supports the demo claim that explicit decision records help later review.
+
+## Detailed Notes
+
+- The paper describes lightweight decision records for review teams.
+- The paper separates screening decisions from final synthesis prose.
+
+## Thesis Connections
+
+- Use in the evidence-review section to motivate claim registers.
+```
+
+- [ ] **Step 4: Create BibTeX file**
+
+Create `examples/demo-project/references.bib`:
+
+```bibtex
+@article{smith2024,
+  title = {Local-first research workflows},
+  author = {Smith, Jane},
+  year = {2024},
+  journal = {Journal of Research Tooling},
+  doi = {10.1000/demo-smith}
+}
+
+@inproceedings{jones2023,
+  title = {Review audit trails for research teams},
+  author = {Jones, Alex},
+  year = {2023},
+  booktitle = {Proceedings of Demo Methods},
+  url = {https://example.org/demo/jones2023}
+}
+```
+
+- [ ] **Step 5: Create evidence-review packet**
+
+Create `examples/demo-project/docs/review_protocol.md`:
+
+```markdown
+# Demo Review Protocol
+
+Question: How can a local academic writing workflow keep source notes, claims, and release checks inspectable?
+
+Scope: This demo uses fictional records to show file structure and validation only.
+```
+
+Create `examples/demo-project/evidence/evidence_matrix.csv`:
+
+```csv
+source_id,citation_key,evidence_status,claim_supported,source_path,notes
+S1,smith2024,verified_artifact,local-first workflows keep notes inspectable,literature/reading_notes/smith2024_NOTES.md,Supports file-based note workflow
+S2,jones2023,verified_artifact,decision records support review audit trails,literature/reading_notes/jones2023_NOTES.md,Supports explicit review records
+```
+
+Create `examples/demo-project/evidence/claim_register.csv`:
+
+```csv
+claim_id,claim_text,evidence_status,sources,scope_boundary,manual_check_needed
+C1,Local-first workflows can separate source notes evidence claims and release checks,verified_artifact,smith2024;jones2023,demo project only,false
+```
+
+Create `examples/demo-project/evidence/citation_plan.csv`:
+
+```csv
+claim_id,citation_key,placement,rationale
+C1,smith2024,chapter introduction,Supports inspectable local note workflow
+C1,jones2023,chapter introduction,Supports explicit audit trail workflow
+```
+
+Create `examples/demo-project/evidence/overclaim_risk_register.csv`:
+
+```csv
+risk_id,claim_id,risk,mitigation,status
+R1,C1,Claim could sound universal,Limit wording to demo workflow and fictional records,mitigated
+```
+
+Create `examples/demo-project/reports/review_summary.md`:
+
+```markdown
+# Demo Review Summary
+
+The demo evidence packet links one workflow claim to two fictional sources and marks one overclaim risk as mitigated.
+```
+
+Create `examples/demo-project/summaries/source_summary.md`:
+
+```markdown
+# Demo Source Summary
+
+Smith 2024 supports local note inspectability. Jones 2023 supports explicit review decision records.
+```
+
+- [ ] **Step 6: Create release-governance packet**
+
+Create `examples/demo-project/release/release_scope.md`:
+
+```markdown
+# Demo Release Scope
+
+This release packet covers the fictional demo chapter and its evidence-review files. It demonstrates packet structure and validator behaviour only.
+```
+
+Create `examples/demo-project/release/canonical_refs.csv`:
+
+```csv
+ref_name,sha,date,status,canonical_for,caveat
+demo-manuscript,abc1234,2026-06-15,locked,chapter-draft,demo checksum not used for publication
+demo-evidence,def5678,2026-06-15,locked,evidence-packet,demo checksum not used for publication
+```
+
+Create `examples/demo-project/release/local_asset_inventory.csv`:
+
+```csv
+path,status,file_count,size,role,release_action
+chapters/ch01.md,present,1,1 KB,manuscript-demo,keep
+evidence/evidence_matrix.csv,present,1,1 KB,evidence-demo,keep
+```
+
+Create `examples/demo-project/release/artifact_anchors.csv`:
+
+```csv
+artifact_id,source_ref,source_path,count_or_checksum,evidence_state,verified_by,claim_supported
+art-chapter-claim,demo-manuscript,chapters/ch01.md,abc1234,verified_artifact,automated-demo-check,local-first workflow claim
+art-evidence-matrix,demo-evidence,evidence/evidence_matrix.csv,def5678,verified_artifact,automated-demo-check,evidence packet structure
+```
+
+Create `examples/demo-project/release/evidence_gates.csv`:
+
+```csv
+gate_id,artifact_id,evidence_state,human_confirmed,reviewer,review_date,validator,status
+gate-1,art-chapter-claim,verified_artifact,false,,,.claude/skills/release-governance/scripts/check_release_packet.py,passed
+gate-2,art-evidence-matrix,verified_artifact,false,,,.claude/skills/release-governance/scripts/check_release_packet.py,passed
+```
+
+Create `examples/demo-project/release/claim_ledger.csv`:
+
+```csv
+claim_id,claim_text,artifact_ids,evidence_state,denominator,scope_boundary,human_gate_required,status
+claim-1,Local-first workflows can separate source notes evidence claims and release checks,art-chapter-claim;art-evidence-matrix,verified_artifact,two fictional demo sources,demo project only,false,ready
+```
+
+Create `examples/demo-project/release/verification_report.md`:
+
+```markdown
+# Demo Verification Report
+
+The demo packet validates with the release-governance checker. The packet demonstrates structure and evidence-state handling, not scholarly truth.
+```
+
+- [ ] **Step 7: Run demo validators**
+
+Run:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+Expected: all three commands exit 0. The release-governance JSON output has `"issue_count": 0`.
+
+- [ ] **Step 8: Run regression suite**
+
+Run:
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: T62 passes. T61 and T63 still fail until use-case docs are created.
+
+- [ ] **Step 9: Commit demo project**
+
+Run:
+
+```bash
+git add examples/demo-project
+git commit -m "docs: add runnable academic workflow demo"
+```
+
+Expected: commit succeeds with only `examples/demo-project/` staged.
+
+## Task 4: Add Use-Case Documentation
+
+**Files:**
+- Create: `docs/use-cases/README.md`
+- Create: `docs/use-cases/write-literature-review.md`
+- Create: `docs/use-cases/audit-thesis-citations.md`
+- Create: `docs/use-cases/verify-references-before-submission.md`
+- Create: `docs/use-cases/prepare-release-governance-packet.md`
+- Create: `docs/use-cases/choose-product-surface.md`
+- Modify: `docs/skills/README.md`
+
+- [ ] **Step 1: Create use-case index**
+
+Create `docs/use-cases/README.md`:
+
+```markdown
+# Use Cases
+
+These guides explain Academic Writing Toolkit by user goal. For the full skill inventory, see the [skills guide](../skills/README.md).
+
+| Goal | Guide |
+|------|-------|
+| Write a literature review | [write-literature-review.md](write-literature-review.md) |
+| Audit thesis citations | [audit-thesis-citations.md](audit-thesis-citations.md) |
+| Verify references before submission | [verify-references-before-submission.md](verify-references-before-submission.md) |
+| Prepare a release-governance packet | [prepare-release-governance-packet.md](prepare-release-governance-packet.md) |
+| Choose the right product surface | [choose-product-surface.md](choose-product-surface.md) |
+```
+
+- [ ] **Step 2: Create literature review guide**
+
+Create `docs/use-cases/write-literature-review.md`:
+
+```markdown
+# Write A Literature Review
+
+Use the local agent skills when your agent can read and write the project folder.
+
+## Workflow
+
+1. Use [`/read`](../skills/01-read.md) to inspect source PDFs or source text.
+2. Use [`/note`](../skills/02-note.md) to create one notes file per source.
+3. Use [`/map`](../skills/04-map.md) to see coverage against chapters.
+4. Use [`/evidence-review`](../skills/12-evidence-review.md) to build evidence matrices, claim registers, citation plans, and overclaim checks.
+5. Use [`/integrate`](../skills/05-integrate.md) to propose chapter edits from completed notes.
+
+## Validate
+
+Run the evidence-review package checker when a review packet exists:
+
+```bash
+python3 .claude/skills/evidence-review/scripts/check_review_package.py . --strict
+```
+
+The checker validates package structure and parseability. It does not replace human judgement about the literature.
+```
+
+- [ ] **Step 3: Create citation audit guide**
+
+Create `docs/use-cases/audit-thesis-citations.md`:
+
+```markdown
+# Audit Thesis Citations
+
+Use citation auditing before major drafts, supervisor review, submission, or release.
+
+## Workflow
+
+1. Confirm the citation style in `CLAUDE.md`.
+2. Use [`/audit`](../skills/06-audit.md) for citation pairing, style-format checks, terminology, numbers, and cross-references.
+3. Use [`/style`](../skills/09-style.md) when British English consistency matters.
+4. Use [`/logic-review`](../skills/10-logic-review.md) to inspect paragraph flow and repeated transitions.
+
+## Validate
+
+Run deterministic checks directly when needed:
+
+```bash
+python3 scripts/audit-citations.py --base-dir . --style harvard --json
+python3 scripts/audit-british-english.py --base-dir . --json
+python3 scripts/audit-logic.py --base-dir . --json
+```
+
+Safe fixers are intentionally narrow. Review suggested edits before applying them to thesis prose.
+```
+
+- [ ] **Step 4: Create reference verification guide**
+
+Create `docs/use-cases/verify-references-before-submission.md`:
+
+```markdown
+# Verify References Before Submission
+
+Use [`/verify-refs`](../skills/11-verify-refs.md) before submission, camera-ready packaging, or bibliography cleanup.
+
+## Workflow
+
+1. Export or collect BibTeX records into a `.bib` file.
+2. Run offline structure checks first.
+3. Add explicit online metadata checks only when network access and external API use are acceptable.
+
+## Validate
+
+```bash
+python3 scripts/verify-refs.py --bib references.bib --json
+python3 scripts/verify-refs.py --bib references.bib --json --online
+```
+
+For deterministic review or CI, use metadata fixtures:
+
+```bash
+python3 scripts/verify-refs.py --bib references.bib --json --online --metadata-dir path/to/metadata-fixtures
+```
+
+The public toolkit intentionally excludes project-specific self-citation rules and author-name assumptions.
+```
+
+- [ ] **Step 5: Create release-governance guide**
+
+Create `docs/use-cases/prepare-release-governance-packet.md`:
+
+```markdown
+# Prepare A Release-Governance Packet
+
+Use [`/release-governance`](../skills/13-release-governance.md) when preparing release, rebuttal, artifact, or camera-ready materials that need explicit evidence-state control.
+
+## Workflow
+
+1. Define the release scope.
+2. Record canonical references and local assets.
+3. Anchor claims to artifacts.
+4. Record evidence gates and human-final confirmations when required.
+5. Run the release packet validator.
+
+## Validate
+
+```bash
+python3 .claude/skills/release-governance/scripts/check_release_packet.py . --json
+```
+
+The validator checks required files, columns, evidence states, parseability, local path leakage, and unresolved working markers. It does not judge scientific validity or venue compliance.
+```
+
+- [ ] **Step 6: Create surface chooser guide**
+
+Create `docs/use-cases/choose-product-surface.md`:
+
+```markdown
+# Choose The Right Product Surface
+
+Academic Writing Toolkit has three public surfaces.
+
+## Local Agent Skills
+
+Use this for the full workflow. The agent can read and write your local project files: chapters, notes, evidence registers, release packets, and exports.
+
+Start here when you use Claude Code, Codex, Gemini CLI, Cursor, or another compatible local agent host.
+
+## Codex Plugin
+
+Use this when you want the same local skills packaged as an installable Codex plugin. The plugin is a distribution wrapper, not a different workflow.
+
+## ChatGPT App MCP Server
+
+Use this for pasted-text checks and reading-note template generation. The ChatGPT App surface processes temporary text inputs only. It does not read or write your local thesis project and does not run the full local workflow.
+
+## Quick Rule
+
+If the task needs project files, use local agent skills. If the task only needs pasted text, the ChatGPT App surface can be enough.
+```
+
+- [ ] **Step 7: Add cross-link from skills guide**
+
+Add this paragraph after the canonical-index sentence in `docs/skills/README.md`:
+
+```markdown
+If you want to start from a goal rather than a skill name, see the [use-case guides](../use-cases/README.md).
+```
+
+- [ ] **Step 8: Run link guard**
+
+Run:
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: T61 and T63 now pass. All tests should pass unless release-readiness docs are still referenced before creation.
+
+- [ ] **Step 9: Commit use-case docs**
+
+Run:
+
+```bash
+git add docs/use-cases docs/skills/README.md
+git commit -m "docs: add use case onboarding guides"
+```
+
+Expected: commit succeeds with only use-case docs and skills index staged.
+
+## Task 5: Add v0.3.0 Release Readiness Doc
+
+**Files:**
+- Create: `docs/product/v0.3.0-release-readiness.md`
+- Modify: `README.md`
+
+- [ ] **Step 1: Create release readiness doc**
+
+Create `docs/product/v0.3.0-release-readiness.md`:
+
+```markdown
+# v0.3.0 Release Readiness
+
+## Release Theme
+
+`v0.3.0` turns Academic Writing Toolkit into a clearer agent-native product surface for evidence-controlled review and release work.
+
+## Included Work
+
+- release-governance skill
+- local agent documentation consistency
+- verify-refs public migration guard
+- agent-native product positioning
+- runnable demo project
+- use-case onboarding guides
+
+## Required Checks
+
+Run these before tagging or publishing:
+
+```bash
+make test
+make plugin-check
+make chatgpt-app-check
+python3 scripts/audit-public-content.py --base-dir .
+git diff --check HEAD
+```
+
+Run the demo validators:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+## Release Notes Draft
+
+Academic Writing Toolkit `v0.3.0` adds release-governance workflows, clearer local-agent product positioning, a runnable demo project, use-case onboarding guides, and stronger public-content guards.
+
+The toolkit remains local-first. The full workflow runs through local agent skills; the Codex plugin packages those skills; the ChatGPT App MCP server remains a narrower pasted-text tool surface.
+
+## Not Included
+
+- Zotero import
+- local document RAG
+- vector search
+- hosted SaaS workflows
+- ChatGPT App access to local project files
+```
+
+- [ ] **Step 2: Link release readiness from README**
+
+Add this sentence near the `Testing And Maintenance` section in `README.md`:
+
+```markdown
+For `v0.3.0` release preparation, use [`docs/product/v0.3.0-release-readiness.md`](docs/product/v0.3.0-release-readiness.md).
+```
+
+- [ ] **Step 3: Run link guard**
+
+Run:
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit release readiness doc**
+
+Run:
+
+```bash
+git add docs/product/v0.3.0-release-readiness.md README.md
+git commit -m "docs: add v0.3.0 release readiness checklist"
+```
+
+Expected: commit succeeds with only README and release-readiness doc staged.
+
+## Task 6: Final Verification And Push
+
+**Files:**
+- Verify all modified files
+
+- [ ] **Step 1: Run full local checks**
+
+Run:
+
+```bash
+make test
+make plugin-check
+make chatgpt-app-check
+python3 scripts/audit-public-content.py --base-dir .
+rg -n 'VU''LCA|EM''NLP|/Users/yhry''zy|TO''DO|TB''D|FIX''ME|PLACE''HOLDER|待''补|待''定' README.md docs examples plugins/academic-writing-toolkit
+git diff --check HEAD
+```
+
+Expected: `make test`, `make plugin-check`, `make chatgpt-app-check`, public-content audit, and diff check pass. The `rg` leakage scan exits with no matches.
+
+- [ ] **Step 2: Check branch state**
+
+Run:
+
+```bash
+git status --short --branch
+git log --oneline --decorate --max-count=8
+```
+
+Expected: worktree is clean. Recent commits show the productization plan, tests, README positioning, demo project, use-case docs, and release readiness.
+
+- [ ] **Step 3: Push branch**
+
+Run:
+
+```bash
+git push
+```
+
+Expected: `codex/release-governance-skill` pushes successfully.
+
+- [ ] **Step 4: Verify PR checks**
+
+Run:
+
+```bash
+gh pr checks 14 --repo yha9806/academic-writing-toolkit --watch
+```
+
+Expected: GitHub checks pass for PR #14.
+
+## Self-Review
+
+Spec coverage:
+
+- README positioning is covered by Task 2.
+- Demo project is covered by Task 3.
+- Use-case docs are covered by Task 4.
+- Product surface separation is covered by Task 2 and Task 4.
+- `v0.3.0` readiness is covered by Task 5.
+- Public-content and validation guards are covered by Task 1 and Task 6.
+
+Scope check:
+
+- No new runtime dependencies are introduced.
+- Zotero import, RAG, vector search, hosted SaaS, and ChatGPT App expansion remain out of scope.
+- Demo content is fictional and generic.
+- Existing validators are reused instead of adding new validation systems.

--- a/docs/product/local-agent-docs-consistency-design.md
+++ b/docs/product/local-agent-docs-consistency-design.md
@@ -56,7 +56,7 @@ The guides should keep their runtime-specific setup details but share the same p
 
 Add a focused test to `scripts/test.sh` that fails when public setup docs drift behind the current local skill set. The guard should check for:
 
-- no stale "11 public academic writing skills" wording
+- no stale fixed-count skill inventory wording
 - presence of `evidence-review` and `release-governance` in local-agent setup docs
 - root README explicitly distinguishing local skills from the ChatGPT App pasted-text surface
 

--- a/docs/product/local-agent-docs-consistency-design.md
+++ b/docs/product/local-agent-docs-consistency-design.md
@@ -1,0 +1,94 @@
+# Local Agent Documentation Consistency Design
+
+## Goal
+
+Make the local agent product surface easier to trust and understand by aligning user-facing documentation with the current skill set and by adding a small regression guard against future documentation drift.
+
+This pass targets local agent users first. It does not add new skills, change academic-writing behaviour, or expand the ChatGPT App surface.
+
+## Current Problem
+
+The toolkit has a coherent local workflow, but the documentation is not equally coherent across entry points. The root README and skills index describe the current pipeline, while some setup guides still describe an older skill count and omit newer governance skills. The ChatGPT App is also a narrower pasted-text tool surface, but that difference is not prominent enough for users choosing an entry point.
+
+The result is product friction: a user can run the toolkit, but may not know which surface is complete, which documentation is canonical, or whether newer skills are meant to be part of the main local workflow.
+
+## Users
+
+Primary user: a local agent user working in Claude Code, Codex, Gemini CLI, OpenClaw, or a compatible host with access to the repository files.
+
+Secondary user: a maintainer reviewing whether public docs match the installed skill set.
+
+Non-goal: making the ChatGPT App equivalent to the local agent workflow.
+
+## Design
+
+### Canonical Skill Inventory
+
+Use `docs/skills/README.md` as the canonical public skill index for user-facing setup docs. It should list the current local agent skills and their guide pages.
+
+Setup guides should avoid stale fixed counts when the exact number is not necessary. When a count is useful, it must be derived from the same current inventory and checked by tests.
+
+### Surface Boundary Wording
+
+Add a short root README section that distinguishes:
+
+- Local agent skills: full file-based workflow with project directories, notes, chapters, evidence controls, release packets, and export.
+- ChatGPT App MCP server: pasted-text checks and template generation through temporary files only.
+- Codex plugin package: distribution wrapper for the local skills.
+
+This prevents an implicit promise that the ChatGPT App can read or write a user's local thesis project.
+
+### Setup Guide Alignment
+
+Update local-agent setup guides so they reflect the same workflow vocabulary:
+
+- `read`, `note`, `verify`, `map`
+- `evidence-review`
+- `integrate`
+- `audit`
+- `release-governance`
+- `style`, `logic-review`, `verify-refs`
+- `progress`, `export`
+
+The guides should keep their runtime-specific setup details but share the same product description.
+
+### Regression Guard
+
+Add a focused test to `scripts/test.sh` that fails when public setup docs drift behind the current local skill set. The guard should check for:
+
+- no stale "11 public academic writing skills" wording
+- presence of `evidence-review` and `release-governance` in local-agent setup docs
+- root README explicitly distinguishing local skills from the ChatGPT App pasted-text surface
+
+The test should stay lightweight and deterministic. It should not inspect network state, GitHub state, or external package metadata.
+
+## Files In Scope
+
+- `README.md`
+- `docs/setup-claude-code.md`
+- `docs/setup-codex-cli.md`
+- `docs/setup-gemini-cli.md`
+- `docs/setup-openclaw.md`
+- `docs/skills/README.md`
+- `plugins/academic-writing-toolkit/README.md`, only if wording needs alignment
+- `scripts/test.sh`
+
+## Files Out Of Scope
+
+- Skill behaviour and skill scripts
+- ChatGPT App tools
+- Plugin publishing metadata beyond wording consistency
+- Example projects and guided tutorials
+- Workflow readiness or next-action automation
+
+## Acceptance Criteria
+
+1. Public setup docs no longer mention the stale 11-skill inventory.
+2. Local-agent setup docs mention both `evidence-review` and `release-governance`.
+3. The root README clearly says the ChatGPT App is a narrower pasted-text tool surface, while local skills are the full file-based workflow.
+4. `make test` includes a regression guard for this documentation consistency.
+5. `make test`, `make plugin-check`, `python3 scripts/audit-public-content.py --base-dir .`, and the public leakage scan pass.
+
+## Risks
+
+The main risk is over-expanding this pass into onboarding redesign. Keep this change narrowly focused on consistency and product boundary clarity. Sample projects, guided tutorials, and workflow readiness should be separate follow-up work.

--- a/docs/product/local-agent-docs-consistency-implementation-plan.md
+++ b/docs/product/local-agent-docs-consistency-implementation-plan.md
@@ -1,0 +1,219 @@
+# Local Agent Documentation Consistency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Align local-agent setup documentation with the current skill set and add an automated drift guard.
+
+**Architecture:** Treat `docs/skills/README.md` as the canonical public local skill index, then align README and runtime setup docs around that inventory. Add a lightweight shell test in `scripts/test.sh` so stale setup wording and missing governance skills fail the normal regression suite.
+
+**Tech Stack:** Markdown docs, Bash test harness in `scripts/test.sh`, existing `make test`, `make plugin-check`, and public-content audit scripts.
+
+---
+
+### Task 1: Add Documentation Drift Guard Test
+
+**Files:**
+- Modify: `scripts/test.sh`
+
+- [ ] **Step 1: Add failing test function**
+
+Insert this function after `test_T58()` in `scripts/test.sh`:
+
+```bash
+test_T59() {
+    local setup_docs=(
+        "$REPO_ROOT/docs/setup-claude-code.md"
+        "$REPO_ROOT/docs/setup-codex-cli.md"
+        "$REPO_ROOT/docs/setup-gemini-cli.md"
+        "$REPO_ROOT/docs/setup-openclaw.md"
+    )
+
+    ! grep -R -q "11 public academic writing skills" "${setup_docs[@]}" || return 1
+
+    local doc
+    for doc in "${setup_docs[@]}"; do
+        grep -q "evidence-review" "$doc" || return 1
+        grep -q "release-governance" "$doc" || return 1
+    done
+
+    grep -q "Local agent skills" "$REPO_ROOT/README.md" || return 1
+    grep -q "ChatGPT App MCP server" "$REPO_ROOT/README.md" || return 1
+    grep -q "pasted-text" "$REPO_ROOT/README.md" || return 1
+}
+```
+
+- [ ] **Step 2: Register the test**
+
+Add this run line after T58:
+
+```bash
+run_test "T59 local-agent docs avoid skill drift" test_T59
+```
+
+Update the header comment from `T54-T58 release governance` to `T54-T58 release governance + T59 docs consistency`, and from `55 automated tests` to `56 automated tests`.
+
+- [ ] **Step 3: Verify red**
+
+Run:
+
+```bash
+bash scripts/test.sh
+```
+
+Expected: test suite fails at `T59 local-agent docs avoid skill drift`, because setup docs still contain stale 11-skill wording and README does not yet have the surface boundary section.
+
+### Task 2: Add Root README Surface Boundary
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add product surfaces section**
+
+Insert this section after the paragraph ending `tool-only ChatGPT App MCP server.`:
+
+```markdown
+## Product Surfaces
+
+The full workflow is the local agent skill set. Use it when an agent can read and write the project files in your clone: chapters, reading notes, evidence registers, release packets, and export outputs.
+
+The Codex plugin packages those same local skills for Codex plugin installation. It is a distribution surface, not a separate workflow.
+
+The ChatGPT App MCP server is narrower. It provides pasted-text checks and template generation through temporary files only; it does not read or write a local thesis project, run the full skill pipeline, or persist user submissions.
+```
+
+- [ ] **Step 2: Verify boundary wording**
+
+Run:
+
+```bash
+grep -n "Product Surfaces" README.md
+grep -n "Local agent skill" README.md
+grep -n "ChatGPT App MCP server" README.md
+grep -n "pasted-text" README.md
+```
+
+Expected: each command prints a matching README line.
+
+### Task 3: Align Local-Agent Setup Guides
+
+**Files:**
+- Modify: `docs/setup-claude-code.md`
+- Modify: `docs/setup-codex-cli.md`
+- Modify: `docs/setup-gemini-cli.md`
+- Modify: `docs/setup-openclaw.md`
+- Modify: `docs/skills/README.md`
+
+- [ ] **Step 1: Update setup verify wording**
+
+In each setup guide, replace the current “You should see...” sentence with the runtime-appropriate version:
+
+```markdown
+You should see the public local agent skills listed in [the skills guide](skills/README.md), including `evidence-review` and `release-governance`.
+```
+
+For `docs/setup-claude-code.md`, use the same sentence with slash-command examples:
+
+```markdown
+You should see the public local agent skills listed in [the skills guide](skills/README.md), including `/evidence-review` and `/release-governance`.
+```
+
+- [ ] **Step 2: Update available skill tables**
+
+Ensure each setup guide’s `Available Skills` table includes these rows in workflow order:
+
+```markdown
+| read | Guided reading with page-by-page PDF extraction |
+| note | Record structured reading notes |
+| verify | Fact-check claims against sources |
+| map | View literature coverage matrix |
+| evidence-review | Build evidence-controlled gap maps and claim registers |
+| integrate | Weave reading notes into chapter drafts |
+| audit | Pre-submission consistency check |
+| release-governance | Prepare release, rebuttal, artifact, and claim packets |
+| style | Check British English consistency |
+| logic-review | Review paragraph flow and transitions |
+| verify-refs | Check BibTeX records and metadata |
+| progress | Writing progress dashboard |
+| export | Export chapters to Word (.docx) and ZIP |
+```
+
+For `docs/setup-claude-code.md`, keep slash-command labels in the first column.
+
+- [ ] **Step 3: Update usage examples**
+
+Add these examples to each setup guide after `audit`:
+
+```text
+evidence-review                       # Build evidence-controlled review maps
+release-governance                    # Prepare release evidence packet
+```
+
+For `docs/setup-claude-code.md`, use slash-command forms:
+
+```text
+/evidence-review                      # Build evidence-controlled review maps
+/release-governance                   # Prepare release evidence packet
+```
+
+- [ ] **Step 4: Fix OpenClaw configuration wording**
+
+In `docs/setup-openclaw.md`, replace:
+
+```markdown
+OpenClaw reads `AGENTS.md` as its project instruction file, but **`AGENTS.md` is auto-generated** from `CLAUDE.md` by sub-project D's tooling.
+```
+
+with:
+
+```markdown
+OpenClaw reads `AGENTS.md` as its project instruction file, but **`AGENTS.md` is auto-generated** from `CLAUDE.md` by this toolkit's sync tooling.
+```
+
+- [ ] **Step 5: Mark the skills guide as canonical**
+
+In `docs/skills/README.md`, after the opening paragraph, add:
+
+```markdown
+This page is the canonical public index for local agent skills. Runtime setup guides should point here rather than maintaining separate skill inventories.
+```
+
+### Task 4: Verify And Commit Documentation Pass
+
+**Files:**
+- Verify all modified docs and tests
+
+- [ ] **Step 1: Run targeted drift checks**
+
+Run:
+
+```bash
+rg -n "11 public academic writing skills" docs README.md
+rg -n "evidence-review|release-governance" docs/setup-claude-code.md docs/setup-codex-cli.md docs/setup-gemini-cli.md docs/setup-openclaw.md
+```
+
+Expected: first command exits with no matches; second command prints matches in all four setup docs.
+
+- [ ] **Step 2: Run full verification**
+
+Run:
+
+```bash
+make test
+make plugin-check
+python3 scripts/audit-public-content.py --base-dir .
+rg -n 'VU''LCA|/Users/yhry''zy|TO''DO|TB''D|FIX''ME|PLACE''HOLDER|待''补|待''定' plugins/academic-writing-toolkit docs README.md
+git diff --check HEAD
+```
+
+Expected: `make test`, `make plugin-check`, public-content audit, and diff check pass. The `rg` leakage scan exits with no matches.
+
+- [ ] **Step 3: Commit**
+
+Run:
+
+```bash
+git add README.md docs/setup-claude-code.md docs/setup-codex-cli.md docs/setup-gemini-cli.md docs/setup-openclaw.md docs/skills/README.md scripts/test.sh docs/product/local-agent-docs-consistency-implementation-plan.md
+git commit -m "docs: align local agent setup guides"
+```
+
+Expected: commit succeeds with only documentation and test-harness changes.

--- a/docs/product/local-agent-docs-consistency-implementation-plan.md
+++ b/docs/product/local-agent-docs-consistency-implementation-plan.md
@@ -28,7 +28,8 @@ test_T59() {
         "$REPO_ROOT/docs/setup-openclaw.md"
     )
 
-    ! grep -R -q "11 public academic writing skills" "${setup_docs[@]}" || return 1
+    local stale_phrase="11 public academic writing skill"
+    ! grep -R -q "${stale_phrase}s" "${setup_docs[@]}" || return 1
 
     local doc
     for doc in "${setup_docs[@]}"; do
@@ -187,7 +188,7 @@ This page is the canonical public index for local agent skills. Runtime setup gu
 Run:
 
 ```bash
-rg -n "11 public academic writing skills" docs README.md
+rg -n "11 public academic writing skill""s" docs README.md
 rg -n "evidence-review|release-governance" docs/setup-claude-code.md docs/setup-codex-cli.md docs/setup-gemini-cli.md docs/setup-openclaw.md
 ```
 

--- a/docs/product/v0.3.0-release-readiness.md
+++ b/docs/product/v0.3.0-release-readiness.md
@@ -1,0 +1,48 @@
+# v0.3.0 Release Readiness
+
+## Release Theme
+
+`v0.3.0` turns Academic Writing Toolkit into a clearer agent-native product surface for evidence-controlled review and release work.
+
+## Included Work
+
+- release-governance skill
+- local agent documentation consistency
+- verify-refs public migration guard
+- agent-native product positioning
+- runnable demo project
+- use-case onboarding guides
+
+## Required Checks
+
+Run these before tagging or publishing:
+
+```bash
+make test
+make plugin-check
+make chatgpt-app-check
+python3 scripts/audit-public-content.py --base-dir .
+git diff --check HEAD
+```
+
+Run the demo validators:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+## Release Notes Draft
+
+Academic Writing Toolkit `v0.3.0` adds release-governance workflows, clearer local-agent product positioning, a runnable demo project, use-case onboarding guides, and stronger public-content guards.
+
+The toolkit remains local-first. The full workflow runs through local agent skills; the Codex plugin packages those skills; the ChatGPT App MCP server remains a narrower pasted-text tool surface.
+
+## Not Included
+
+- Zotero import
+- local document RAG
+- vector search
+- hosted SaaS workflows
+- ChatGPT App access to local project files

--- a/docs/setup-claude-code.md
+++ b/docs/setup-claude-code.md
@@ -30,23 +30,25 @@ If `make doctor` reports anything red, run `make repair` to fix what it can.
 
 Ask Claude: "What skills are available?"
 
-You should see: `/read`, `/note`, `/verify`, `/map`, `/integrate`, `/audit`, `/style`, `/logic-review`, `/verify-refs`, `/progress`, `/export`
+You should see the public local agent skills listed in [the skills guide](skills/README.md), including `/evidence-review` and `/release-governance`.
 
 ## Available Skills
 
-| Command      | Purpose                              |
-|--------------|--------------------------------------|
-| `/read`      | Guided reading with page-by-page PDF extraction |
-| `/note`      | Record structured reading notes      |
-| `/verify`    | Fact-check claims against sources    |
-| `/map`       | View literature coverage matrix      |
+| Command | Purpose |
+|---------|---------|
+| `/read` | Guided reading with page-by-page PDF extraction |
+| `/note` | Record structured reading notes |
+| `/verify` | Fact-check claims against sources |
+| `/map` | View literature coverage matrix |
+| `/evidence-review` | Build evidence-controlled gap maps and claim registers |
 | `/integrate` | Weave reading notes into chapter drafts |
-| `/audit`     | Pre-submission consistency check     |
-| `/style`     | Check British English consistency    |
+| `/audit` | Pre-submission consistency check |
+| `/release-governance` | Prepare release, rebuttal, artifact, and claim packets |
+| `/style` | Check British English consistency |
 | `/logic-review` | Review paragraph flow and transitions |
 | `/verify-refs` | Check BibTeX records and metadata |
-| `/progress`  | Writing progress dashboard           |
-| `/export`    | Export chapters to Word (.docx) + ZIP |
+| `/progress` | Writing progress dashboard |
+| `/export` | Export chapters to Word (.docx) and ZIP |
 
 ## Customise
 
@@ -71,8 +73,10 @@ cp -r .claude/skills/* ~/.claude/skills/
 /note                                 # Record notes from reading
 /verify Smith published the article in 2020  # Fact-check a claim
 /map                                  # See literature coverage matrix
+/evidence-review                      # Build evidence-controlled review maps
 /integrate                            # Weave notes into chapters
 /audit                                # Pre-submission consistency check
+/release-governance                   # Prepare release evidence packet
 /style                                # Check British English consistency
 /logic-review                         # Review paragraph flow
 /verify-refs references.bib           # Check BibTeX records

--- a/docs/setup-codex-cli.md
+++ b/docs/setup-codex-cli.md
@@ -30,23 +30,25 @@ If `make doctor` reports anything red, run `make repair` to fix what it can.
 
 Ask Codex: "What skills are available?"
 
-You should see the 11 public academic writing skills: read, note, verify, map, integrate, audit, style, logic-review, verify-refs, progress, export.
+You should see the public local agent skills listed in [the skills guide](skills/README.md), including `evidence-review` and `release-governance`.
 
 ## Available Skills
 
-| Skill     | Purpose                              |
-|-----------|--------------------------------------|
-| read      | Guided reading with page-by-page PDF extraction |
-| note      | Record structured reading notes      |
-| verify    | Fact-check claims against sources    |
-| map       | View literature coverage matrix      |
+| Skill | Purpose |
+|-------|---------|
+| read | Guided reading with page-by-page PDF extraction |
+| note | Record structured reading notes |
+| verify | Fact-check claims against sources |
+| map | View literature coverage matrix |
+| evidence-review | Build evidence-controlled gap maps and claim registers |
 | integrate | Weave reading notes into chapter drafts |
-| audit     | Pre-submission consistency check     |
-| style     | Check British English consistency    |
+| audit | Pre-submission consistency check |
+| release-governance | Prepare release, rebuttal, artifact, and claim packets |
+| style | Check British English consistency |
 | logic-review | Review paragraph flow and transitions |
 | verify-refs | Check BibTeX records and metadata |
-| progress  | Writing progress dashboard           |
-| export    | Export chapters to Word (.docx) + ZIP |
+| progress | Writing progress dashboard |
+| export | Export chapters to Word (.docx) and ZIP |
 
 ## Configuration
 
@@ -74,8 +76,10 @@ read literature/my-paper.pdf         # Start reading a paper
 note                                  # Record notes from reading
 verify Smith published the article in 2020  # Fact-check a claim
 map                                   # See literature coverage matrix
+evidence-review                       # Build evidence-controlled review maps
 integrate                             # Weave notes into chapters
 audit                                 # Pre-submission consistency check
+release-governance                    # Prepare release evidence packet
 style                                 # Check British English consistency
 logic-review                          # Review paragraph flow
 verify-refs references.bib            # Check BibTeX records

--- a/docs/setup-gemini-cli.md
+++ b/docs/setup-gemini-cli.md
@@ -30,23 +30,25 @@ If `make doctor` reports anything red, run `make repair` to fix what it can.
 
 Ask Gemini: "What skills are available?"
 
-You should see the 11 public academic writing skills: read, note, verify, map, integrate, audit, style, logic-review, verify-refs, progress, export.
+You should see the public local agent skills listed in [the skills guide](skills/README.md), including `evidence-review` and `release-governance`.
 
 ## Available Skills
 
-| Skill     | Purpose                              |
-|-----------|--------------------------------------|
-| read      | Guided reading with page-by-page PDF extraction |
-| note      | Record structured reading notes      |
-| verify    | Fact-check claims against sources    |
-| map       | View literature coverage matrix      |
+| Skill | Purpose |
+|-------|---------|
+| read | Guided reading with page-by-page PDF extraction |
+| note | Record structured reading notes |
+| verify | Fact-check claims against sources |
+| map | View literature coverage matrix |
+| evidence-review | Build evidence-controlled gap maps and claim registers |
 | integrate | Weave reading notes into chapter drafts |
-| audit     | Pre-submission consistency check     |
-| style     | Check British English consistency    |
+| audit | Pre-submission consistency check |
+| release-governance | Prepare release, rebuttal, artifact, and claim packets |
+| style | Check British English consistency |
 | logic-review | Review paragraph flow and transitions |
 | verify-refs | Check BibTeX records and metadata |
-| progress  | Writing progress dashboard           |
-| export    | Export chapters to Word (.docx) + ZIP |
+| progress | Writing progress dashboard |
+| export | Export chapters to Word (.docx) and ZIP |
 
 ## Configuration
 
@@ -71,8 +73,10 @@ read literature/my-paper.pdf         # Start reading a paper
 note                                  # Record notes from reading
 verify Smith published the article in 2020  # Fact-check a claim
 map                                   # See literature coverage matrix
+evidence-review                       # Build evidence-controlled review maps
 integrate                             # Weave notes into chapters
 audit                                 # Pre-submission consistency check
+release-governance                    # Prepare release evidence packet
 style                                 # Check British English consistency
 logic-review                          # Review paragraph flow
 verify-refs references.bib            # Check BibTeX records

--- a/docs/setup-openclaw.md
+++ b/docs/setup-openclaw.md
@@ -18,27 +18,29 @@ Skills are loaded from `.agents/skills/` (symlinked to `.claude/skills/`).
 
 Ask OpenClaw: "What skills are available?"
 
-You should see the 11 public academic writing skills: read, note, verify, map, integrate, audit, style, logic-review, verify-refs, progress, export.
+You should see the public local agent skills listed in [the skills guide](skills/README.md), including `evidence-review` and `release-governance`.
 
 ## Available Skills
 
-| Skill     | Purpose                              |
-|-----------|--------------------------------------|
-| read      | Guided reading with page-by-page PDF extraction |
-| note      | Record structured reading notes      |
-| verify    | Fact-check claims against sources    |
-| map       | View literature coverage matrix      |
+| Skill | Purpose |
+|-------|---------|
+| read | Guided reading with page-by-page PDF extraction |
+| note | Record structured reading notes |
+| verify | Fact-check claims against sources |
+| map | View literature coverage matrix |
+| evidence-review | Build evidence-controlled gap maps and claim registers |
 | integrate | Weave reading notes into chapter drafts |
-| audit     | Pre-submission consistency check     |
-| style     | Check British English consistency    |
+| audit | Pre-submission consistency check |
+| release-governance | Prepare release, rebuttal, artifact, and claim packets |
+| style | Check British English consistency |
 | logic-review | Review paragraph flow and transitions |
 | verify-refs | Check BibTeX records and metadata |
-| progress  | Writing progress dashboard           |
-| export    | Export chapters to Word (.docx) + ZIP |
+| progress | Writing progress dashboard |
+| export | Export chapters to Word (.docx) and ZIP |
 
 ## Configuration
 
-OpenClaw reads `AGENTS.md` as its project instruction file, but **`AGENTS.md` is auto-generated** from `CLAUDE.md` by sub-project D's tooling. To customise:
+OpenClaw reads `AGENTS.md` as its project instruction file, but **`AGENTS.md` is auto-generated** from `CLAUDE.md` by this toolkit's sync tooling. To customise:
 
 1. Edit `CLAUDE.md` (the canonical source — the SHARED block is what gets regenerated).
 2. Run `make sync` to regenerate `AGENTS.md` (and `GEMINI.md`).
@@ -66,8 +68,10 @@ read literature/my-paper.pdf         # Start reading a paper
 note                                  # Record notes from reading
 verify Smith published the article in 2020  # Fact-check a claim
 map                                   # See literature coverage matrix
+evidence-review                       # Build evidence-controlled review maps
 integrate                             # Weave notes into chapters
 audit                                 # Pre-submission consistency check
+release-governance                    # Prepare release evidence packet
 style                                 # Check British English consistency
 logic-review                          # Review paragraph flow
 verify-refs references.bib            # Check BibTeX records

--- a/docs/skills/13-release-governance.md
+++ b/docs/skills/13-release-governance.md
@@ -1,0 +1,55 @@
+# /release-governance - Release Evidence Governance
+
+Run `/release-governance` before manuscript submission, rebuttal, camera-ready work, dataset release, artifact handoff, or claim-register freeze when claims depend on multiple refs, local assets, human labels, or agent-assisted drafts.
+
+The core rule is:
+
+```text
+release truth = ref + artifact + gate
+```
+
+Use it after `/evidence-review` and `/audit` when the work moves from drafting into release or rebuttal hardening.
+
+## What It Produces
+
+- `release/release_scope.md`
+- `release/canonical_refs.csv`
+- `release/local_asset_inventory.csv`
+- `release/artifact_anchors.csv`
+- `release/evidence_gates.csv`
+- `release/claim_ledger.csv`
+- `release/verification_report.md`
+
+## Evidence States
+
+The release packet uses:
+
+- `draft_advisory` for agent reviews, Gemini reviews, prefills, simulations, and provisional notes
+- `verified_artifact` for checked files, manifests, counts, checksums, tables, figures, and exports
+- `human_final` for explicit human confirmation with reviewer identity or role, review date, and matching scope
+
+Agent or Gemini review is useful as advisory risk review, but it cannot promote evidence to `human_final`.
+
+## Typical Use
+
+```text
+/release-governance Build a release packet for this camera-ready artifact using local refs only.
+```
+
+```text
+/release-governance Audit whether these human label claims are supported by explicit confirmation gates.
+```
+
+```text
+/release-governance Prepare a rebuttal handoff with canonical refs, artifact anchors, and residual risks.
+```
+
+## Optional Check
+
+The skill includes a lightweight helper:
+
+```bash
+python .claude/skills/release-governance/scripts/check_release_packet.py .
+```
+
+It checks required packet files, CSV/JSON/YAML readability, legal evidence-state values, required columns, local absolute paths, and unresolved template markers. YAML files use PyYAML when installed; otherwise the helper applies a basic local syntax check for simple mappings and lists. It does not replace expert review, venue checks, ethics checks, licensing checks, or scientific validation.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -4,6 +4,8 @@ This toolkit provides local agent skills for academic writing projects. Skills a
 
 This page is the canonical public index for local agent skills. Runtime setup guides should point here rather than maintaining separate skill inventories.
 
+If you want to start from a goal rather than a skill name, see the [use-case guides](../use-cases/README.md).
+
 ## Pipeline
 
 ```text

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -5,7 +5,7 @@ This toolkit provides local agent skills for academic writing projects. Skills a
 ## Pipeline
 
 ```text
-/read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /style -> /logic-review -> /export
+/read -> /note -> /map -> /evidence-review -> /integrate -> /audit -> /release-governance -> /style -> /logic-review -> /export
              |                                      |
              v                                      v
         /verify                               /verify-refs
@@ -25,6 +25,7 @@ This toolkit provides local agent skills for academic writing projects. Skills a
 | `/evidence-review` | [12-evidence-review.md](12-evidence-review.md) |
 | `/integrate` | [05-integrate.md](05-integrate.md) |
 | `/audit` | [06-audit.md](06-audit.md) |
+| `/release-governance` | [13-release-governance.md](13-release-governance.md) |
 | `/progress` | [07-progress.md](07-progress.md) |
 | `/export` | [08-export.md](08-export.md) |
 | `/style` | [09-style.md](09-style.md) |

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -2,6 +2,8 @@
 
 This toolkit provides local agent skills for academic writing projects. Skills are discovered from `.claude/skills/` by Claude Code and from `.agents/skills/` by Codex, Gemini, and compatible hosts.
 
+This page is the canonical public index for local agent skills. Runtime setup guides should point here rather than maintaining separate skill inventories.
+
 ## Pipeline
 
 ```text

--- a/docs/use-cases/README.md
+++ b/docs/use-cases/README.md
@@ -1,0 +1,11 @@
+# Use Cases
+
+These guides explain Academic Writing Toolkit by user goal. For the full skill inventory, see the [skills guide](../skills/README.md).
+
+| Goal | Guide |
+|------|-------|
+| Write a literature review | [write-literature-review.md](write-literature-review.md) |
+| Audit thesis citations | [audit-thesis-citations.md](audit-thesis-citations.md) |
+| Verify references before submission | [verify-references-before-submission.md](verify-references-before-submission.md) |
+| Prepare a release-governance packet | [prepare-release-governance-packet.md](prepare-release-governance-packet.md) |
+| Choose the right product surface | [choose-product-surface.md](choose-product-surface.md) |

--- a/docs/use-cases/audit-thesis-citations.md
+++ b/docs/use-cases/audit-thesis-citations.md
@@ -1,0 +1,22 @@
+# Audit Thesis Citations
+
+Use citation auditing before major drafts, supervisor review, submission, or release.
+
+## Workflow
+
+1. Confirm the citation style in `CLAUDE.md`.
+2. Use [`/audit`](../skills/06-audit.md) for citation pairing, style-format checks, terminology, numbers, and cross-references.
+3. Use [`/style`](../skills/09-style.md) when British English consistency matters.
+4. Use [`/logic-review`](../skills/10-logic-review.md) to inspect paragraph flow and repeated transitions.
+
+## Validate
+
+Run deterministic checks directly when needed:
+
+```bash
+python3 scripts/audit-citations.py --base-dir . --style harvard --json
+python3 scripts/audit-british-english.py --base-dir . --json
+python3 scripts/audit-logic.py --base-dir . --json
+```
+
+Safe fixers are intentionally narrow. Review suggested edits before applying them to thesis prose.

--- a/docs/use-cases/choose-product-surface.md
+++ b/docs/use-cases/choose-product-surface.md
@@ -1,0 +1,21 @@
+# Choose The Right Product Surface
+
+Academic Writing Toolkit has three public surfaces.
+
+## Local Agent Skills
+
+Use this for the full workflow. The agent can read and write your local project files: chapters, notes, evidence registers, release packets, and exports.
+
+Start here when you use Claude Code, Codex, Gemini CLI, Cursor, or another compatible local agent host.
+
+## Codex Plugin
+
+Use this when you want the same local skills packaged as an installable Codex plugin. The plugin is a distribution wrapper, not a different workflow.
+
+## ChatGPT App MCP Server
+
+Use this for pasted-text checks and reading-note template generation. The ChatGPT App surface processes temporary text inputs only. It does not read or write your local thesis project and does not run the full local workflow.
+
+## Quick Rule
+
+If the task needs project files, use local agent skills. If the task only needs pasted text, the ChatGPT App surface can be enough.

--- a/docs/use-cases/prepare-release-governance-packet.md
+++ b/docs/use-cases/prepare-release-governance-packet.md
@@ -1,0 +1,19 @@
+# Prepare A Release-Governance Packet
+
+Use [`/release-governance`](../skills/13-release-governance.md) when preparing release, rebuttal, artifact, or camera-ready materials that need explicit evidence-state control.
+
+## Workflow
+
+1. Define the release scope.
+2. Record canonical references and local assets.
+3. Anchor claims to artifacts.
+4. Record evidence gates and human-final confirmations when required.
+5. Run the release packet validator.
+
+## Validate
+
+```bash
+python3 .claude/skills/release-governance/scripts/check_release_packet.py . --json
+```
+
+The validator checks required files, columns, evidence states, parseability, local path leakage, and unresolved working markers. It does not judge scientific validity or venue compliance.

--- a/docs/use-cases/verify-references-before-submission.md
+++ b/docs/use-cases/verify-references-before-submission.md
@@ -1,0 +1,24 @@
+# Verify References Before Submission
+
+Use [`/verify-refs`](../skills/11-verify-refs.md) before submission, camera-ready packaging, or bibliography cleanup.
+
+## Workflow
+
+1. Export or collect BibTeX records into a `.bib` file.
+2. Run offline structure checks first.
+3. Add explicit online metadata checks only when network access and external API use are acceptable.
+
+## Validate
+
+```bash
+python3 scripts/verify-refs.py --bib references.bib --json
+python3 scripts/verify-refs.py --bib references.bib --json --online
+```
+
+For deterministic review or CI, use metadata fixtures:
+
+```bash
+python3 scripts/verify-refs.py --bib references.bib --json --online --metadata-dir path/to/metadata-fixtures
+```
+
+The public toolkit intentionally excludes project-specific self-citation rules and author-name assumptions.

--- a/docs/use-cases/write-literature-review.md
+++ b/docs/use-cases/write-literature-review.md
@@ -1,0 +1,21 @@
+# Write A Literature Review
+
+Use the local agent skills when your agent can read and write the project folder.
+
+## Workflow
+
+1. Use [`/read`](../skills/01-read.md) to inspect source PDFs or source text.
+2. Use [`/note`](../skills/02-note.md) to create one notes file per source.
+3. Use [`/map`](../skills/04-map.md) to see coverage against chapters.
+4. Use [`/evidence-review`](../skills/12-evidence-review.md) to build evidence matrices, claim registers, citation plans, and overclaim checks.
+5. Use [`/integrate`](../skills/05-integrate.md) to propose chapter edits from completed notes.
+
+## Validate
+
+Run the evidence-review package checker when a review packet exists:
+
+```bash
+python3 .claude/skills/evidence-review/scripts/check_review_package.py . --strict
+```
+
+The checker validates package structure and parseability. It does not replace human judgement about the literature.

--- a/examples/demo-project/AGENTS.md
+++ b/examples/demo-project/AGENTS.md
@@ -1,0 +1,13 @@
+# Demo Academic Writing Project
+
+Follow `CLAUDE.md` for the demo workflow. Use the repository-level Academic Writing Toolkit skills when available.
+
+## Checks
+
+Run these from the repository root when validating the demo:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```

--- a/examples/demo-project/CLAUDE.md
+++ b/examples/demo-project/CLAUDE.md
@@ -1,0 +1,16 @@
+# Demo Academic Writing Project
+
+This is a public demo for Academic Writing Toolkit. It uses fictional source records and generic claims.
+
+## Directories
+
+- Chapters: `chapters/`
+- Literature notes: `literature/reading_notes/`
+- Evidence review packet: `evidence/`
+- Release packet: `release/`
+
+## Writing Principles
+
+- Keep claims tied to reading notes.
+- Use British English in chapter prose.
+- Treat release packet checks as auditability checks, not human academic approval.

--- a/examples/demo-project/GEMINI.md
+++ b/examples/demo-project/GEMINI.md
@@ -1,0 +1,5 @@
+# Demo Academic Writing Project
+
+This demo mirrors the local agent workflow described in `CLAUDE.md`.
+
+Use it to explain or inspect the workflow. Do not treat the fictional sources as real scholarship.

--- a/examples/demo-project/README.md
+++ b/examples/demo-project/README.md
@@ -1,0 +1,25 @@
+# Demo Project
+
+This demo shows the local Academic Writing Toolkit workflow without private research material.
+
+Run these commands from the repository root:
+
+```bash
+python3 scripts/verify-refs.py --bib examples/demo-project/references.bib --json
+python3 .claude/skills/evidence-review/scripts/check_review_package.py examples/demo-project --strict
+python3 .claude/skills/release-governance/scripts/check_release_packet.py examples/demo-project --json
+```
+
+The demo includes:
+
+- a short chapter draft in [`chapters/ch01.md`](chapters/ch01.md)
+- two reading notes in [`literature/reading_notes/`](literature/reading_notes/)
+- a BibTeX file in [`references.bib`](references.bib)
+- an evidence-review packet in [`evidence/`](evidence/)
+- a release-governance packet in [`release/`](release/)
+
+Open this folder in Codex, Claude Code, Gemini CLI, Cursor, or another compatible local agent and ask:
+
+```text
+Explain how this demo project moves from reading notes to evidence review and release governance.
+```

--- a/examples/demo-project/chapters/ch01.md
+++ b/examples/demo-project/chapters/ch01.md
@@ -1,0 +1,5 @@
+# Chapter 1: Local-first Review Workflow
+
+Local-first academic writing workflows benefit from separating source notes, evidence claims, and release checks (Smith 2024; Jones 2023).
+
+Smith (2024) describes a file-based workflow where notes and claims remain inspectable. Jones (2023) focuses on review audit trails and argues that explicit decision records make later synthesis easier to check.

--- a/examples/demo-project/docs/review_protocol.md
+++ b/examples/demo-project/docs/review_protocol.md
@@ -1,0 +1,5 @@
+# Demo Review Protocol
+
+Question: How can a local academic writing workflow keep source notes, claims, and release checks inspectable?
+
+Scope: This demo uses fictional records to show file structure and validation only.

--- a/examples/demo-project/evidence/citation_plan.csv
+++ b/examples/demo-project/evidence/citation_plan.csv
@@ -1,0 +1,3 @@
+claim_id,citation_key,placement,rationale
+C1,smith2024,chapter introduction,Supports inspectable local note workflow
+C1,jones2023,chapter introduction,Supports explicit audit trail workflow

--- a/examples/demo-project/evidence/claim_register.csv
+++ b/examples/demo-project/evidence/claim_register.csv
@@ -1,0 +1,2 @@
+claim_id,claim_text,evidence_status,sources,scope_boundary,manual_check_needed
+C1,Local-first workflows can separate source notes evidence claims and release checks,verified_artifact,smith2024;jones2023,demo project only,false

--- a/examples/demo-project/evidence/evidence_matrix.csv
+++ b/examples/demo-project/evidence/evidence_matrix.csv
@@ -1,0 +1,3 @@
+source_id,citation_key,evidence_status,claim_supported,source_path,notes
+S1,smith2024,verified_artifact,local-first workflows keep notes inspectable,literature/reading_notes/smith2024_NOTES.md,Supports file-based note workflow
+S2,jones2023,verified_artifact,decision records support review audit trails,literature/reading_notes/jones2023_NOTES.md,Supports explicit review records

--- a/examples/demo-project/evidence/overclaim_risk_register.csv
+++ b/examples/demo-project/evidence/overclaim_risk_register.csv
@@ -1,0 +1,2 @@
+risk_id,claim_id,risk,mitigation,status
+R1,C1,Claim could sound universal,Limit wording to demo workflow and fictional records,mitigated

--- a/examples/demo-project/literature/reading_notes/jones2023_NOTES.md
+++ b/examples/demo-project/literature/reading_notes/jones2023_NOTES.md
@@ -1,0 +1,17 @@
+# Jones 2023 Notes
+
+**Status**: complete
+**Source**: Jones, Alex (2023). Review audit trails for research teams. Proceedings of Demo Methods.
+
+## Relevance
+
+Supports the demo claim that explicit decision records help later review.
+
+## Detailed Notes
+
+- The paper describes lightweight decision records for review teams.
+- The paper separates screening decisions from final synthesis prose.
+
+## Thesis Connections
+
+- Use in the evidence-review section to motivate claim registers.

--- a/examples/demo-project/literature/reading_notes/smith2024_NOTES.md
+++ b/examples/demo-project/literature/reading_notes/smith2024_NOTES.md
@@ -1,0 +1,17 @@
+# Smith 2024 Notes
+
+**Status**: complete
+**Source**: Smith, Jane (2024). Local-first research workflows. Journal of Research Tooling.
+
+## Relevance
+
+Supports the demo claim that local files can keep notes and claims inspectable.
+
+## Detailed Notes
+
+- The article describes storing source notes beside draft materials.
+- The article treats auditability as a workflow property.
+
+## Thesis Connections
+
+- Use in the introduction to explain why local-first workflows matter.

--- a/examples/demo-project/references.bib
+++ b/examples/demo-project/references.bib
@@ -1,0 +1,15 @@
+@article{smith2024,
+  title = {Local-first research workflows},
+  author = {Smith, Jane},
+  year = {2024},
+  journal = {Journal of Research Tooling},
+  doi = {10.1000/demo-smith}
+}
+
+@inproceedings{jones2023,
+  title = {Review audit trails for research teams},
+  author = {Jones, Alex},
+  year = {2023},
+  booktitle = {Proceedings of Demo Methods},
+  url = {https://example.org/demo/jones2023}
+}

--- a/examples/demo-project/release/artifact_anchors.csv
+++ b/examples/demo-project/release/artifact_anchors.csv
@@ -1,0 +1,3 @@
+artifact_id,source_ref,source_path,count_or_checksum,evidence_state,verified_by,claim_supported
+art-chapter-claim,demo-manuscript,chapters/ch01.md,abc1234,verified_artifact,automated-demo-check,local-first workflow claim
+art-evidence-matrix,demo-evidence,evidence/evidence_matrix.csv,def5678,verified_artifact,automated-demo-check,evidence packet structure

--- a/examples/demo-project/release/canonical_refs.csv
+++ b/examples/demo-project/release/canonical_refs.csv
@@ -1,0 +1,3 @@
+ref_name,sha,date,status,canonical_for,caveat
+demo-manuscript,abc1234,2026-06-15,locked,chapter-draft,demo checksum not used for publication
+demo-evidence,def5678,2026-06-15,locked,evidence-packet,demo checksum not used for publication

--- a/examples/demo-project/release/claim_ledger.csv
+++ b/examples/demo-project/release/claim_ledger.csv
@@ -1,0 +1,2 @@
+claim_id,claim_text,artifact_ids,evidence_state,denominator,scope_boundary,human_gate_required,status
+claim-1,Local-first workflows can separate source notes evidence claims and release checks,art-chapter-claim;art-evidence-matrix,verified_artifact,two fictional demo sources,demo project only,false,ready

--- a/examples/demo-project/release/evidence_gates.csv
+++ b/examples/demo-project/release/evidence_gates.csv
@@ -1,0 +1,3 @@
+gate_id,artifact_id,evidence_state,human_confirmed,reviewer,review_date,validator,status
+gate-1,art-chapter-claim,verified_artifact,false,,,.claude/skills/release-governance/scripts/check_release_packet.py,passed
+gate-2,art-evidence-matrix,verified_artifact,false,,,.claude/skills/release-governance/scripts/check_release_packet.py,passed

--- a/examples/demo-project/release/local_asset_inventory.csv
+++ b/examples/demo-project/release/local_asset_inventory.csv
@@ -1,0 +1,3 @@
+path,status,file_count,size,role,release_action
+chapters/ch01.md,present,1,1 KB,manuscript-demo,keep
+evidence/evidence_matrix.csv,present,1,1 KB,evidence-demo,keep

--- a/examples/demo-project/release/release_scope.md
+++ b/examples/demo-project/release/release_scope.md
@@ -1,0 +1,3 @@
+# Demo Release Scope
+
+This release packet covers the fictional demo chapter and its evidence-review files. It demonstrates packet structure and validator behaviour only.

--- a/examples/demo-project/release/verification_report.md
+++ b/examples/demo-project/release/verification_report.md
@@ -1,0 +1,3 @@
+# Demo Verification Report
+
+The demo packet validates with the release-governance checker. The packet demonstrates structure and evidence-state handling, not scholarly truth.

--- a/examples/demo-project/reports/review_summary.md
+++ b/examples/demo-project/reports/review_summary.md
@@ -1,0 +1,3 @@
+# Demo Review Summary
+
+The demo evidence packet links one workflow claim to two fictional sources and marks one overclaim risk as mitigated.

--- a/examples/demo-project/summaries/source_summary.md
+++ b/examples/demo-project/summaries/source_summary.md
@@ -1,0 +1,3 @@
+# Demo Source Summary
+
+Smith 2024 supports local note inspectability. Jones 2023 supports explicit review decision records.

--- a/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
+++ b/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
@@ -3,8 +3,7 @@
   "version": "0.2.0",
   "description": "Academic reading, thesis writing, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, and export skills for Codex.",
   "author": {
-    "name": "Yu, Haorui",
-    "email": "yuhaorui48@gmail.com",
+    "name": "Academic Writing Toolkit Maintainers",
     "url": "https://github.com/yha9806"
   },
   "homepage": "https://github.com/yha9806/academic-writing-toolkit",
@@ -26,7 +25,7 @@
     "displayName": "Academic Writing Toolkit",
     "shortDescription": "Structured research, thesis writing, evidence-review, release governance, citation, style, and export workflows.",
     "longDescription": "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, integrating arguments, auditing citations and consistency, preparing release-governance packets, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
-    "developerName": "Yu, Haorui",
+    "developerName": "Academic Writing Toolkit Maintainers",
     "category": "Productivity",
     "capabilities": [
       "Read",

--- a/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
+++ b/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "academic-writing-toolkit",
   "version": "0.2.0",
-  "description": "Academic reading, thesis writing, evidence-controlled review synthesis, citation auditing, British English checking, reference verification, and export skills for Codex.",
+  "description": "Academic reading, thesis writing, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, and export skills for Codex.",
   "author": {
     "name": "Yu, Haorui",
     "email": "yuhaorui48@gmail.com",
@@ -18,13 +18,14 @@
     "british-english",
     "references",
     "evidence-review",
+    "release-governance",
     "literature-review"
   ],
   "skills": "./skills/",
   "interface": {
     "displayName": "Academic Writing Toolkit",
-    "shortDescription": "Structured research, thesis writing, evidence-review, citation, style, and export workflows.",
-    "longDescription": "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, integrating arguments, auditing citations and consistency, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
+    "shortDescription": "Structured research, thesis writing, evidence-review, release governance, citation, style, and export workflows.",
+    "longDescription": "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, integrating arguments, auditing citations and consistency, preparing release-governance packets, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
     "developerName": "Yu, Haorui",
     "category": "Productivity",
     "capabilities": [
@@ -38,7 +39,7 @@
     "defaultPrompt": [
       "Read this paper and extract thesis connections.",
       "Build an evidence-controlled gap map for my literature review.",
-      "Check my thesis draft for British English."
+      "Prepare a release-governance packet for my camera-ready artifact."
     ],
     "brandColor": "#2563EB",
     "composerIcon": "./assets/icon.png",

--- a/plugins/academic-writing-toolkit/README.md
+++ b/plugins/academic-writing-toolkit/README.md
@@ -11,6 +11,7 @@ This Codex plugin packages the academic-writing-toolkit skills for structured re
 - `evidence-review`: build evidence-controlled literature gap maps, claim registers, citation plans, and overclaim audits
 - `integrate`: integrate completed reading notes into chapter drafts
 - `audit`: audit citation consistency, numbers, terminology, and cross-references
+- `release-governance`: prepare release, rebuttal, artifact, and claim packets with ref-artifact-gate controls
 - `style`: check and safely fix common US spellings when British English is required
 - `logic-review`: review paragraph flow and transition issues
 - `verify-refs`: validate BibTeX and reference metadata
@@ -24,6 +25,7 @@ The skills expect a writing project with these directories when relevant:
 - `chapters/`
 - `literature/`
 - `literature/reading_notes/`
+- `release/`
 - `final_output/`
 
 Script-backed skills use helper scripts bundled inside the individual skill directories, so the plugin can run without copying the repository-level `scripts/` directory into a user's project.

--- a/plugins/academic-writing-toolkit/skills/release-governance/SKILL.md
+++ b/plugins/academic-writing-toolkit/skills/release-governance/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: release-governance
+description: Use when preparing, auditing, releasing, or rebuttal-hardening academic manuscripts, datasets, artifacts, reviewer packets, or claim registers involving multiple refs, local assets, human labels, or agent-assisted drafts.
+allowed-tools: Read, Glob, Grep, Bash, Edit, Write
+---
+
+# /release-governance - Release Evidence Governance
+
+## Purpose
+
+Prepare release-facing academic artifacts with explicit evidence control. The core rule is:
+
+```text
+release truth = ref + artifact + gate
+```
+
+Do not infer release truth from memory, a branch name, a pull request title, a local file cache, or an agent draft.
+
+## Trigger Words
+
+This skill activates on: `release governance`, `release evidence`, `camera-ready`, `rebuttal packet`, `artifact packet`, `claim ledger`, `human evidence gate`, `release packet`, `/release-governance`.
+
+## Core Rules
+
+1. Name the exact ref, artifact, and gate behind every release-facing claim.
+2. Keep draft advisory evidence, verified artifacts, and final human evidence separate.
+3. Do not promote agent or Gemini review output into final evidence.
+4. Do not treat ignored, untracked, cached, or local-only assets as submitted artifacts.
+5. Do not treat a repository check as venue, submission-system, or scientific compliance.
+6. If two refs diverge, name both and scope which one is canonical for each artifact.
+7. If a worktree is dirty, list the dirty paths and mark the packet as draft until changes are committed or explicitly scoped.
+
+## Evidence States
+
+Use `references/evidence_state_schema.md` for the shared states:
+
+- `draft_advisory`
+- `verified_artifact`
+- `human_final`
+
+`human_final` requires an explicit human confirmation gate when the project schema provides one. Agent drafts, reviewer suggestions, generated summaries, simulations, and prefilled labels stay `draft_advisory`.
+
+## Workflow
+
+### 1. Declare Scope
+
+Create `release/release_scope.md` with scope date, artifact name, intended use, included refs, excluded refs, and the highest-risk open question.
+
+### 2. Map Repository Truth
+
+Run narrow ref checks before reading a checkout as final state:
+
+```bash
+git fetch --all --prune
+git status --short --branch
+git worktree list --porcelain
+git branch --all --verbose --no-abbrev
+```
+
+Create `release/canonical_refs.csv`. Detached HEADs are acceptable only when the exact SHA is recorded.
+
+### 3. Inventory Assets
+
+Create `release/local_asset_inventory.csv` to separate tracked, ignored, untracked, external-store, and generated assets. Local assets may support review, but release claims require an artifact anchor or explicit exclusion.
+
+### 4. Anchor Artifacts And Claims
+
+Create:
+
+- `release/artifact_anchors.csv`
+- `release/claim_ledger.csv`
+- `release/evidence_gates.csv`
+
+Every paper-facing number, qualitative conclusion, table value, figure, dataset count, and human-label claim should point to the artifact and gate that support it.
+
+### 5. Review Advisory Evidence
+
+Gemini or another agent may review the scope, packet, or diff, but its result is advisory. Record advisory review in the verification report without changing any evidence state to `human_final`.
+
+### 6. Verify Packet
+
+Use `references/release_workflow_templates.md` for columns and report structure. If Python is available, run:
+
+```bash
+python {skill_dir}/scripts/check_release_packet.py <project_root>
+```
+
+The helper checks required packet files, CSV/JSON/YAML readability, evidence-state values, required columns, local absolute paths, and obvious template markers. YAML files use PyYAML when installed; otherwise the helper applies a basic local syntax check for simple mappings and lists. It does not run experiments, access networks, push branches, or judge scientific validity.
+
+## Stop Conditions
+
+Stop and report a blocker if:
+
+- a final claim depends on a dirty or ambiguous ref
+- a human-label claim lacks a human confirmation gate
+- a release artifact exists only as an ignored, untracked, cache, or local-only file
+- a count comes from a pointer, stub, generated preview, or non-canonical ref
+- a draft pull request, closed-unmerged pull request, or advisory review is being treated as final release state
+- the packet validator reports issues that affect release-facing claims

--- a/plugins/academic-writing-toolkit/skills/release-governance/references/evidence_state_schema.md
+++ b/plugins/academic-writing-toolkit/skills/release-governance/references/evidence_state_schema.md
@@ -1,0 +1,39 @@
+# Release Evidence State Schema
+
+Release governance uses three states so agent-assisted drafts, verified files, and final human evidence stay visibly separate.
+
+| State | Meaning | Allowed use | Promotion gate |
+| --- | --- | --- | --- |
+| `draft_advisory` | Agent review, Gemini review, prefill output, simulation, draft label, reviewer note, or provisional working file. | Planning, triage, risk review, candidate wording, and follow-up tracking. | Cannot support final claims. Requires artifact verification or human confirmation before promotion. |
+| `verified_artifact` | A concrete file, count, checksum, manifest, figure, table, dataset slice, or export has been checked against an exact ref or named external artifact. | Artifact existence, provenance, counts, checksums, and bounded claims within the verified scope. | Requires a command, checksum, manifest, or manual artifact check recorded in the packet. |
+| `human_final` | A human reviewer, adjudicator, coordinator, or author has explicitly confirmed the evidence according to the project gate. | Human-label claims, adjudication conclusions, reviewer decisions, final wording approvals, and release sign-off. | Requires explicit human confirmation fields, reviewer identity or role, review date, and matching denominator or scope. |
+
+## Minimal Packet Schema
+
+Required files:
+
+- `release/release_scope.md`
+- `release/canonical_refs.csv`
+- `release/local_asset_inventory.csv`
+- `release/artifact_anchors.csv`
+- `release/evidence_gates.csv`
+- `release/claim_ledger.csv`
+- `release/verification_report.md`
+
+Required CSV columns:
+
+| File | Columns |
+| --- | --- |
+| `canonical_refs.csv` | `ref_name`, `sha`, `date`, `status`, `canonical_for`, `caveat` |
+| `local_asset_inventory.csv` | `path`, `status`, `file_count`, `size`, `role`, `release_action` |
+| `artifact_anchors.csv` | `artifact_id`, `source_ref`, `source_path`, `count_or_checksum`, `evidence_state`, `verified_by`, `claim_supported` |
+| `evidence_gates.csv` | `gate_id`, `artifact_id`, `evidence_state`, `human_confirmed`, `reviewer`, `review_date`, `validator`, `status` |
+| `claim_ledger.csv` | `claim_id`, `claim_text`, `artifact_ids`, `evidence_state`, `denominator`, `scope_boundary`, `human_gate_required`, `status` |
+
+## Gate Rules
+
+1. `draft_advisory` rows must not be described as final evidence.
+2. `verified_artifact` rows need an exact ref, artifact path, manifest, count, checksum, or recorded manual check.
+3. `human_final` rows need explicit confirmation, reviewer or coordinator identity, review date, and a denominator or scope boundary.
+4. Agent or Gemini review can flag risks, but it cannot promote any row to `human_final`.
+5. Repository checks prove repository state only; they do not prove venue, ethics, licensing, or scientific compliance.

--- a/plugins/academic-writing-toolkit/skills/release-governance/references/release_workflow_templates.md
+++ b/plugins/academic-writing-toolkit/skills/release-governance/references/release_workflow_templates.md
@@ -1,0 +1,107 @@
+# Release Workflow Templates
+
+These templates are intentionally file-driven. They are for manuscripts, datasets, review packets, artifact bundles, claim registers, rebuttal packages, and camera-ready checks.
+
+## Scope
+
+`release/release_scope.md`
+
+```text
+# Release Scope
+
+Scope date: 2026-05-31
+Paper/artifact: Generic review packet
+Deadline/use: collaborator handoff
+Included refs: refs/heads/main at abcdef1234567890
+Excluded refs: none
+Open question: whether an optional asset should stay local-only
+```
+
+## Canonical Refs
+
+`release/canonical_refs.csv`
+
+```text
+ref_name,sha,date,status,canonical_for,caveat
+main,abcdef1234567890,2026-05-31,clean,manuscript,none
+```
+
+## Local Asset Inventory
+
+`release/local_asset_inventory.csv`
+
+```text
+path,status,file_count,size,role,release_action
+figures/source/tracked.png,tracked,1,42K,figure source,keep tracked
+data/private-cache,ignored,120,80M,local review cache,exclude and document boundary
+```
+
+Allowed status values can be project-specific, but common values are `tracked`, `ignored`, `untracked`, `external-store`, and `generated`.
+
+## Artifact Anchors
+
+`release/artifact_anchors.csv`
+
+```text
+artifact_id,source_ref,source_path,count_or_checksum,evidence_state,verified_by,claim_supported
+fig1,main,figures/source/tracked.png,sha256:abc,verified_artifact,manual checksum,figure provenance
+```
+
+## Evidence Gates
+
+`release/evidence_gates.csv`
+
+```text
+gate_id,artifact_id,evidence_state,human_confirmed,reviewer,review_date,validator,status
+gate1,fig1,human_final,true,Reviewer One,2026-05-31,manual packet review,passed
+```
+
+Use `draft_advisory` for agent or Gemini reviews. Use `verified_artifact` for deterministic artifact checks. Use `human_final` only for explicit human confirmation.
+
+## Claim Ledger
+
+`release/claim_ledger.csv`
+
+```text
+claim_id,claim_text,artifact_ids,evidence_state,denominator,scope_boundary,human_gate_required,status
+c1,The figure is anchored to a tracked source artifact,fig1,verified_artifact,one figure,provenance only,false,supported
+```
+
+Check every row for:
+
+- stale denominators
+- subset-to-universe inflation
+- "final", "submitted", "merged", or "human" wording unsupported by the gate
+- local-only assets used as if they were release artifacts
+- advisory reviews used as final evidence
+
+## Verification Report
+
+`release/verification_report.md`
+
+```text
+# Verification Report
+
+Canonical refs:
+- main at abcdef1234567890 -> manuscript and tracked artifacts
+
+Advisory reviews:
+- Gemini scope review -> risks reviewed; no evidence-state promotion
+
+Verification:
+- python .claude/skills/release-governance/scripts/check_release_packet.py . -> clean
+- git diff --check -> clean
+
+Residual risk:
+- Optional external asset still needs owner decision before submission.
+```
+
+## Handoff Packet
+
+End release or rebuttal handoff with:
+
+| Item | Location | Ref/SHA | Owner | Next action |
+| --- | --- | --- | --- | --- |
+| Manuscript | `chapters/` or final export | exact SHA | author | final venue checklist |
+| Artifact manifest | `release/artifact_anchors.csv` | exact SHA | maintainer | checksum review |
+| Claim ledger | `release/claim_ledger.csv` | exact SHA | reviewer | approve or revise unsupported claims |

--- a/plugins/academic-writing-toolkit/skills/release-governance/scripts/check_release_packet.py
+++ b/plugins/academic-writing-toolkit/skills/release-governance/scripts/check_release_packet.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Lightweight validation for release-governance packets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+ALLOWED_EVIDENCE_STATES = {"draft_advisory", "verified_artifact", "human_final"}
+
+REQUIRED_FILES: Dict[str, Sequence[str]] = {
+    "release/release_scope.md": (),
+    "release/canonical_refs.csv": ("ref_name", "sha", "date", "status", "canonical_for", "caveat"),
+    "release/local_asset_inventory.csv": ("path", "status", "file_count", "size", "role", "release_action"),
+    "release/artifact_anchors.csv": (
+        "artifact_id",
+        "source_ref",
+        "source_path",
+        "count_or_checksum",
+        "evidence_state",
+        "verified_by",
+        "claim_supported",
+    ),
+    "release/evidence_gates.csv": (
+        "gate_id",
+        "artifact_id",
+        "evidence_state",
+        "human_confirmed",
+        "reviewer",
+        "review_date",
+        "validator",
+        "status",
+    ),
+    "release/claim_ledger.csv": (
+        "claim_id",
+        "claim_text",
+        "artifact_ids",
+        "evidence_state",
+        "denominator",
+        "scope_boundary",
+        "human_gate_required",
+        "status",
+    ),
+    "release/verification_report.md": (),
+}
+
+TEXT_EXTENSIONS = {".csv", ".json", ".md", ".txt", ".yaml", ".yml"}
+STRUCTURED_EXTENSIONS = {".csv", ".json", ".yaml", ".yml"}
+
+UNRESOLVED_CJK_MARKERS = "|".join((chr(0x5F85) + chr(0x8865), chr(0x5F85) + chr(0x5B9A)))
+MARKER_RE = re.compile(
+    r"\b(to\s*do|tbd|fix\s*me|xxx|replace me|fill in|pending update|placeholder|path/to|sample only)\b|"
+    + UNRESOLVED_CJK_MARKERS,
+    re.IGNORECASE,
+)
+LOCAL_PATH_RE = re.compile(
+    r"(^|[\s'\"(,;:])((/[Uu]sers|/[Hh]ome|/[Pp]rivate|/[Tt]mp|/[Vv]ar/[Ff]olders)(/|\b)|[A-Za-z]:\\)"
+)
+
+
+def issue(kind: str, path: str, detail: str, line: Optional[int] = None) -> Dict[str, object]:
+    item: Dict[str, object] = {"kind": kind, "path": path, "detail": detail}
+    if line is not None:
+        item["line"] = line
+    return item
+
+
+def iter_packet_files(root: Path) -> Iterable[Path]:
+    release_dir = root / "release"
+    if not release_dir.is_dir():
+        return []
+    return (path for path in sorted(release_dir.rglob("*")) if path.is_file())
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8-sig")
+
+
+def check_text(path: Path, rel: str) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    if path.suffix.lower() not in TEXT_EXTENSIONS:
+        return issues
+    try:
+        text = read_text(path)
+    except UnicodeDecodeError as exc:
+        return [issue("decode-error", rel, str(exc))]
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if MARKER_RE.search(line):
+            issues.append(issue("placeholder-text", rel, "remove unresolved template marker or working note", line_no))
+        if LOCAL_PATH_RE.search(line):
+            issues.append(issue("local-absolute-path", rel, "replace local absolute path with a relative path or external artifact identifier", line_no))
+    return issues
+
+
+def read_csv(path: Path) -> Tuple[List[str], List[Dict[str, str]]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        rows = list(reader)
+    if reader.fieldnames is None:
+        raise ValueError("no header row")
+    return list(reader.fieldnames), rows
+
+
+def parse_yaml_fallback(text: str) -> None:
+    stack = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("- "):
+            stack.append(line)
+            continue
+        if ":" not in line:
+            raise ValueError("line is not a simple yaml mapping or list item")
+
+
+def parse_structured(path: Path) -> None:
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        read_csv(path)
+    elif suffix == ".json":
+        json.loads(read_text(path))
+    elif suffix in {".yaml", ".yml"}:
+        text = read_text(path)
+        try:
+            import yaml  # type: ignore
+        except Exception:
+            parse_yaml_fallback(text)
+        else:
+            yaml.safe_load(text)
+
+
+def check_required_file(root: Path, rel: str, columns: Sequence[str]) -> List[Dict[str, object]]:
+    path = root / rel
+    if not path.exists():
+        return [issue("missing-file", rel, "required release packet file is missing")]
+    if not path.is_file():
+        return [issue("not-file", rel, "required path is not a file")]
+    if path.suffix.lower() != ".csv":
+        return []
+    try:
+        fieldnames, rows = read_csv(path)
+    except Exception as exc:
+        return [issue("csv-parse-error", rel, str(exc))]
+    missing = [column for column in columns if column not in fieldnames]
+    issues: List[Dict[str, object]] = []
+    if missing:
+        issues.append(issue("missing-columns", rel, ", ".join(missing)))
+    issues.extend(check_evidence_states(rel, rows))
+    issues.extend(check_human_final_gate(rel, rows))
+    return issues
+
+
+def check_evidence_states(rel: str, rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    for index, row in enumerate(rows, start=2):
+        value = (row.get("evidence_state") or "").strip()
+        if value and value not in ALLOWED_EVIDENCE_STATES:
+            issues.append(issue("invalid-evidence-state", rel, value, index))
+    return issues
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"true", "yes", "y", "1", "confirmed", "passed"}
+
+
+def check_human_final_gate(rel: str, rows: List[Dict[str, str]]) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    for index, row in enumerate(rows, start=2):
+        if (row.get("evidence_state") or "").strip() != "human_final":
+            continue
+        if "human_confirmed" in row and not truthy(row.get("human_confirmed", "")):
+            issues.append(issue("human-final-gate-missing", rel, "human_final row needs human_confirmed=true", index))
+        if "reviewer" in row and not row.get("reviewer", "").strip():
+            issues.append(issue("human-final-gate-missing", rel, "human_final row needs reviewer", index))
+        if "review_date" in row and not row.get("review_date", "").strip():
+            issues.append(issue("human-final-gate-missing", rel, "human_final row needs review_date", index))
+    return issues
+
+
+def validate(root: Path) -> List[Dict[str, object]]:
+    issues: List[Dict[str, object]] = []
+    release_dir = root / "release"
+    if not release_dir.is_dir():
+        issues.append(issue("missing-directory", "release", "release packet directory is missing"))
+
+    for rel, columns in REQUIRED_FILES.items():
+        issues.extend(check_required_file(root, rel, columns))
+
+    for path in iter_packet_files(root):
+        rel = path.relative_to(root).as_posix()
+        issues.extend(check_text(path, rel))
+        if path.suffix.lower() in STRUCTURED_EXTENSIONS:
+            try:
+                parse_structured(path)
+            except Exception as exc:
+                issues.append(issue("parse-error", rel, str(exc)))
+    return issues
+
+
+def emit_text(root: Path, issues: List[Dict[str, object]]) -> None:
+    print("Release packet root: {}".format(root))
+    if not issues:
+        print("- no release packet issues detected")
+        return
+    print("- issues: {}".format(len(issues)))
+    for item in issues:
+        location = item["path"]
+        if "line" in item:
+            location = "{}:{}".format(location, item["line"])
+        print("- {kind}: {location}: {detail}".format(location=location, **item))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate a release-governance packet.")
+    parser.add_argument("root", nargs="?", default=".", help="project root containing release/")
+    parser.add_argument("--json", action="store_true", dest="emit_json", help="emit machine-readable output")
+    args = parser.parse_args()
+
+    root = Path(args.root).resolve()
+    if not root.is_dir():
+        sys.stderr.write("error: root is not a directory\n")
+        return 2
+
+    issues = validate(root)
+    payload = {
+        "schema_version": 1,
+        "root": str(root),
+        "issues": issues,
+        "issue_count": len(issues),
+        "allowed_evidence_states": sorted(ALLOWED_EVIDENCE_STATES),
+    }
+    if args.emit_json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        emit_text(root, issues)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/academic-writing-toolkit/skills/verify-refs/scripts/verify-refs.py
+++ b/plugins/academic-writing-toolkit/skills/verify-refs/scripts/verify-refs.py
@@ -3,8 +3,8 @@
 
 The default mode is deterministic and CI-safe: parse BibTeX, validate required
 fields, duplicate keys, DOI shape, URL shape, and arXiv identifier shape.
-Online metadata checks can be added later behind an explicit flag without
-changing the offline contract.
+Online metadata checks are available behind an explicit flag without changing
+the offline contract.
 """
 
 import argparse

--- a/scripts/audit-public-content.py
+++ b/scripts/audit-public-content.py
@@ -40,7 +40,7 @@ def tokens() -> List[str]:
 def public_files(base_dir: Path) -> Iterable[Path]:
     roots = [
         "README.md", "CLAUDE.md", "AGENTS.md", "GEMINI.md", "Makefile",
-        "docs", ".claude/skills", ".cursor", "templates", "scripts", "tests",
+        "docs", "examples", ".claude/skills", ".cursor", "templates", "scripts", "tests",
         "plugins/academic-writing-toolkit",
     ]
     for item in roots:

--- a/scripts/audit-public-content.py
+++ b/scripts/audit-public-content.py
@@ -41,6 +41,7 @@ def public_files(base_dir: Path) -> Iterable[Path]:
     roots = [
         "README.md", "CLAUDE.md", "AGENTS.md", "GEMINI.md", "Makefile",
         "docs", ".claude/skills", ".cursor", "templates", "scripts", "tests",
+        "plugins/academic-writing-toolkit",
     ]
     for item in roots:
         path = base_dir / item

--- a/scripts/check-plugin.sh
+++ b/scripts/check-plugin.sh
@@ -117,7 +117,7 @@ if grep -R "\[TODO\]\|TODO:" "$PLUGIN_ROOT" "$MARKETPLACE_JSON" >/dev/null; then
     die "plugin package contains TODO placeholders"
 fi
 
-for skill in audit evidence-review export integrate logic-review map note progress read style verify verify-refs; do
+for skill in audit evidence-review export integrate logic-review map note progress read release-governance style verify verify-refs; do
     [[ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]] || die "missing plugin skill: $skill"
 done
 
@@ -127,5 +127,6 @@ python3 "$PLUGIN_ROOT/skills/logic-review/scripts/audit-logic.py" --help >/dev/n
 python3 "$PLUGIN_ROOT/skills/verify-refs/scripts/verify-refs.py" --help >/dev/null
 python3 "$PLUGIN_ROOT/skills/export/scripts/convert_to_docx.py" --help >/dev/null
 python3 "$PLUGIN_ROOT/skills/evidence-review/scripts/check_review_package.py" --help >/dev/null
+python3 "$PLUGIN_ROOT/skills/release-governance/scripts/check_release_packet.py" --help >/dev/null
 
 ok "plugin package validates"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -712,7 +712,12 @@ for path in files:
         if not target:
             continue
         candidate = (path.parent / target).resolve()
-        if not str(candidate).startswith(str(root.resolve())) or not candidate.exists():
+        try:
+            candidate.relative_to(root.resolve())
+        except ValueError:
+            missing.append(f"{path.relative_to(root)} -> {target}")
+            continue
+        if not candidate.exists():
             missing.append(f"{path.relative_to(root)} -> {target}")
 if missing:
     raise SystemExit("\n".join(missing))

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/test.sh — runs the regression test suite (57 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX) for academic-writing-toolkit.
+# scripts/test.sh — runs the regression test suite (60 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX + T61-T63 productization) for academic-writing-toolkit.
 # Self-contained; saves and restores any state it mutates.
 # Exit 0 if all tests pass, 1 if any fail. CI-suitable.
 # Note: pipefail is intentionally NOT enabled. Several tests assert that a
@@ -643,6 +643,82 @@ EOF
     echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['entries'] == 1 and not d['issues']"
 }
 
+test_T61() {
+    local demo="$REPO_ROOT/examples/demo-project"
+    local use_cases="$REPO_ROOT/docs/use-cases"
+
+    [[ -f "$demo/README.md" ]] || return 1
+    [[ -f "$demo/CLAUDE.md" ]] || return 1
+    [[ -f "$demo/AGENTS.md" ]] || return 1
+    [[ -f "$demo/GEMINI.md" ]] || return 1
+    [[ -f "$demo/chapters/ch01.md" ]] || return 1
+    [[ -f "$demo/literature/reading_notes/smith2024_NOTES.md" ]] || return 1
+    [[ -f "$demo/literature/reading_notes/jones2023_NOTES.md" ]] || return 1
+    [[ -f "$demo/references.bib" ]] || return 1
+
+    [[ -f "$use_cases/README.md" ]] || return 1
+    [[ -f "$use_cases/write-literature-review.md" ]] || return 1
+    [[ -f "$use_cases/audit-thesis-citations.md" ]] || return 1
+    [[ -f "$use_cases/verify-references-before-submission.md" ]] || return 1
+    [[ -f "$use_cases/prepare-release-governance-packet.md" ]] || return 1
+    [[ -f "$use_cases/choose-product-surface.md" ]] || return 1
+
+    grep -q "agent-native" "$REPO_ROOT/README.md" || return 1
+    grep -q "local-first" "$REPO_ROOT/README.md" || return 1
+    grep -q "10-minute demo" "$REPO_ROOT/README.md" || return 1
+    grep -q "docs/use-cases" "$REPO_ROOT/README.md" || return 1
+    grep -q "examples/demo-project" "$REPO_ROOT/README.md" || return 1
+}
+
+test_T62() {
+    local demo="$REPO_ROOT/examples/demo-project"
+    local out
+
+    python3 scripts/verify-refs.py --bib "$demo/references.bib" --json >/dev/null || return 1
+    python3 .claude/skills/evidence-review/scripts/check_review_package.py "$demo" --strict >/dev/null || return 1
+    out=$(python3 .claude/skills/release-governance/scripts/check_release_packet.py "$demo" --json) || return 1
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['issue_count'] == 0"
+}
+
+test_T63() {
+    python3 - "$REPO_ROOT" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+files = [
+    root / "README.md",
+    root / "docs/use-cases/README.md",
+    root / "docs/use-cases/write-literature-review.md",
+    root / "docs/use-cases/audit-thesis-citations.md",
+    root / "docs/use-cases/verify-references-before-submission.md",
+    root / "docs/use-cases/prepare-release-governance-packet.md",
+    root / "docs/use-cases/choose-product-surface.md",
+    root / "examples/demo-project/README.md",
+]
+pattern = re.compile(r"!?\[[^\]]+\]\(([^)]+)\)")
+missing = []
+for path in files:
+    if not path.is_file():
+        missing.append(str(path.relative_to(root)))
+        continue
+    text = path.read_text(encoding="utf-8")
+    for match in pattern.finditer(text):
+        target = match.group(1).strip()
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue
+        target = target.split("#", 1)[0]
+        if not target:
+            continue
+        candidate = (path.parent / target).resolve()
+        if not str(candidate).startswith(str(root.resolve())) or not candidate.exists():
+            missing.append(f"{path.relative_to(root)} -> {target}")
+if missing:
+    raise SystemExit("\n".join(missing))
+PY
+}
+
 test_T50() {
     bash scripts/sync-plugin.sh --check >/dev/null
 }
@@ -854,6 +930,9 @@ run_test "T57 release packet validator rejects local paths and placeholders" tes
 run_test "T58 release packet validator stays local-only" test_T58
 run_test "T59 local-agent docs avoid skill drift" test_T59
 run_test "T60 verify-refs accepts Markdown BibTeX fences" test_T60
+run_test "T61 productization docs and demo structure exist" test_T61
+run_test "T62 demo project validates with existing checkers" test_T62
+run_test "T63 productization docs keep local links valid" test_T63
 
 header ""
 if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/test.sh — runs the regression test suite (55 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance) for academic-writing-toolkit.
+# scripts/test.sh — runs the regression test suite (56 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency) for academic-writing-toolkit.
 # Self-contained; saves and restores any state it mutates.
 # Exit 0 if all tests pass, 1 if any fail. CI-suitable.
 # Note: pipefail is intentionally NOT enabled. Several tests assert that a
@@ -740,6 +740,28 @@ test_T58() {
     ! grep -Eq '\b(subprocess|socket|requests|urllib|http\.client|ftplib)\b' .claude/skills/release-governance/scripts/check_release_packet.py
 }
 
+test_T59() {
+    local setup_docs=(
+        "$REPO_ROOT/docs/setup-claude-code.md"
+        "$REPO_ROOT/docs/setup-codex-cli.md"
+        "$REPO_ROOT/docs/setup-gemini-cli.md"
+        "$REPO_ROOT/docs/setup-openclaw.md"
+    )
+
+    local stale_phrase="11 public academic writing skill"
+    ! grep -R -q "${stale_phrase}s" "${setup_docs[@]}" || return 1
+
+    local doc
+    for doc in "${setup_docs[@]}"; do
+        grep -q "evidence-review" "$doc" || return 1
+        grep -q "release-governance" "$doc" || return 1
+    done
+
+    grep -q "Local agent skills" "$REPO_ROOT/README.md" || return 1
+    grep -q "ChatGPT App MCP server" "$REPO_ROOT/README.md" || return 1
+    grep -q "pasted-text" "$REPO_ROOT/README.md" || return 1
+}
+
 # ----------------------------------------------------------------------------
 header "Running spec §6 acceptance tests..."
 header ""
@@ -805,6 +827,7 @@ run_test "T55 release packet validator rejects invalid evidence state" test_T55
 run_test "T56 release packet validator rejects missing columns" test_T56
 run_test "T57 release packet validator rejects local paths and placeholders" test_T57
 run_test "T58 release packet validator stays local-only" test_T58
+run_test "T59 local-agent docs avoid skill drift" test_T59
 
 header ""
 if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/test.sh — runs the regression test suite (56 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency) for academic-writing-toolkit.
+# scripts/test.sh — runs the regression test suite (57 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX) for academic-writing-toolkit.
 # Self-contained; saves and restores any state it mutates.
 # Exit 0 if all tests pass, 1 if any fail. CI-suitable.
 # Note: pipefail is intentionally NOT enabled. Several tests assert that a
@@ -618,6 +618,31 @@ test_T49() {
     python3 scripts/verify-refs.py --help | grep -q -- "--metadata-dir"
 }
 
+test_T60() {
+    local tmp out
+    tmp=$(mktemp -d) || return 1
+    mkdir -p "$tmp/refs"
+    cat > "$tmp/refs/papers.md" <<'EOF'
+# References
+
+```bibtex
+@article{smith2024,
+  title = {A Generic Toolkit Study},
+  author = {Smith, Jane},
+  year = {2024},
+  journal = {Journal of Tools},
+  doi = {10.1000/example}
+}
+```
+EOF
+    out=$(python3 scripts/verify-refs.py "$tmp/refs/papers.md" --json) || {
+        rm -rf "$tmp"
+        return 1
+    }
+    rm -rf "$tmp"
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['entries'] == 1 and not d['issues']"
+}
+
 test_T50() {
     bash scripts/sync-plugin.sh --check >/dev/null
 }
@@ -828,6 +853,7 @@ run_test "T56 release packet validator rejects missing columns" test_T56
 run_test "T57 release packet validator rejects local paths and placeholders" test_T57
 run_test "T58 release packet validator stays local-only" test_T58
 run_test "T59 local-agent docs avoid skill drift" test_T59
+run_test "T60 verify-refs accepts Markdown BibTeX fences" test_T60
 
 header ""
 if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/test.sh — runs the regression test suite (50 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging) for academic-writing-toolkit.
+# scripts/test.sh — runs the regression test suite (55 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance) for academic-writing-toolkit.
 # Self-contained; saves and restores any state it mutates.
 # Exit 0 if all tests pass, 1 if any fail. CI-suitable.
 # Note: pipefail is intentionally NOT enabled. Several tests assert that a
@@ -641,6 +641,105 @@ test_T53() {
     ! grep -Rq 'removeprefix' "$REPO_ROOT/scripts/check-plugin.sh" "$REPO_ROOT/scripts/sync-plugin.sh"
 }
 
+_make_valid_release_packet() {
+    local tmp="$1"
+    mkdir -p "$tmp/release"
+    cat > "$tmp/release/release_scope.md" <<'EOF'
+# Release Scope
+
+Scope date: 2026-05-31
+Paper/artifact: Generic review packet
+Deadline/use: collaborator handoff
+Included refs: refs/heads/main at abcdef1234567890
+Excluded refs: none
+Open question: whether one optional figure should stay local-only
+EOF
+    cat > "$tmp/release/canonical_refs.csv" <<'EOF'
+ref_name,sha,date,status,canonical_for,caveat
+main,abcdef1234567890,2026-05-31,clean,manuscript,none
+EOF
+    cat > "$tmp/release/local_asset_inventory.csv" <<'EOF'
+path,status,file_count,size,role,release_action
+figures/source/tracked.png,tracked,1,42K,figure source,keep tracked
+EOF
+    cat > "$tmp/release/artifact_anchors.csv" <<'EOF'
+artifact_id,source_ref,source_path,count_or_checksum,evidence_state,verified_by,claim_supported
+fig1,main,figures/source/tracked.png,sha256:abc,verified_artifact,manual checksum,figure provenance
+EOF
+    cat > "$tmp/release/evidence_gates.csv" <<'EOF'
+gate_id,artifact_id,evidence_state,human_confirmed,reviewer,review_date,validator,status
+gate1,fig1,human_final,true,Reviewer One,2026-05-31,manual packet review,passed
+EOF
+    cat > "$tmp/release/claim_ledger.csv" <<'EOF'
+claim_id,claim_text,artifact_ids,evidence_state,denominator,scope_boundary,human_gate_required,status
+c1,The figure is anchored to a tracked source artifact,fig1,verified_artifact,one figure,provenance only,false,supported
+EOF
+    cat > "$tmp/release/verification_report.md" <<'EOF'
+# Verification Report
+
+Verification:
+- packet validator -> clean
+
+Residual risk:
+- Optional figure still needs owner decision before submission.
+EOF
+}
+
+test_T54() {
+    local tmp
+    tmp=$(mktemp -d) || return 1
+    _make_valid_release_packet "$tmp"
+    python3 .claude/skills/release-governance/scripts/check_release_packet.py "$tmp" >/dev/null
+    local rc=$?
+    rm -rf "$tmp"
+    return "$rc"
+}
+
+test_T55() {
+    local tmp out rc
+    tmp=$(mktemp -d) || return 1
+    _make_valid_release_packet "$tmp"
+    sed 's/verified_artifact/agent_final/' "$tmp/release/artifact_anchors.csv" > "$tmp/release/artifact_anchors.tmp"
+    mv "$tmp/release/artifact_anchors.tmp" "$tmp/release/artifact_anchors.csv"
+    out=$(python3 .claude/skills/release-governance/scripts/check_release_packet.py "$tmp" --json 2>&1)
+    rc=$?
+    rm -rf "$tmp"
+    [[ "$rc" -eq 1 ]] || return 1
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); kinds={i['kind'] for i in d['issues']}; assert 'invalid-evidence-state' in kinds"
+}
+
+test_T56() {
+    local tmp out rc
+    tmp=$(mktemp -d) || return 1
+    _make_valid_release_packet "$tmp"
+    cat > "$tmp/release/claim_ledger.csv" <<'EOF'
+claim_id,claim_text,artifact_ids,evidence_state,denominator,status
+c1,The figure is anchored to a tracked source artifact,fig1,verified_artifact,one figure,supported
+EOF
+    out=$(python3 .claude/skills/release-governance/scripts/check_release_packet.py "$tmp" --json 2>&1)
+    rc=$?
+    rm -rf "$tmp"
+    [[ "$rc" -eq 1 ]] || return 1
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); kinds={i['kind'] for i in d['issues']}; assert 'missing-columns' in kinds"
+}
+
+test_T57() {
+    local tmp out rc
+    tmp=$(mktemp -d) || return 1
+    _make_valid_release_packet "$tmp"
+    printf '\nLocal cache: /tmp/private-release-cache\n' >> "$tmp/release/verification_report.md"
+    printf '\nFollow-up: todo before sharing\n' >> "$tmp/release/release_scope.md"
+    out=$(python3 .claude/skills/release-governance/scripts/check_release_packet.py "$tmp" --json 2>&1)
+    rc=$?
+    rm -rf "$tmp"
+    [[ "$rc" -eq 1 ]] || return 1
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); kinds={i['kind'] for i in d['issues']}; assert 'local-absolute-path' in kinds and 'placeholder-text' in kinds"
+}
+
+test_T58() {
+    ! grep -Eq '\b(subprocess|socket|requests|urllib|http\.client|ftplib)\b' .claude/skills/release-governance/scripts/check_release_packet.py
+}
+
 # ----------------------------------------------------------------------------
 header "Running spec §6 acceptance tests..."
 header ""
@@ -701,6 +800,11 @@ run_test "T50 plugin skills are synced" test_T50
 run_test "T51 plugin package validates" test_T51
 run_test "T52 plugin sync ignores bytecode caches" test_T52
 run_test "T53 plugin checks are Python 3.8 compatible" test_T53
+run_test "T54 release packet validator accepts a clean packet" test_T54
+run_test "T55 release packet validator rejects invalid evidence state" test_T55
+run_test "T56 release packet validator rejects missing columns" test_T56
+run_test "T57 release packet validator rejects local paths and placeholders" test_T57
+run_test "T58 release packet validator stays local-only" test_T58
 
 header ""
 if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then

--- a/scripts/verify-refs.py
+++ b/scripts/verify-refs.py
@@ -3,8 +3,8 @@
 
 The default mode is deterministic and CI-safe: parse BibTeX, validate required
 fields, duplicate keys, DOI shape, URL shape, and arXiv identifier shape.
-Online metadata checks can be added later behind an explicit flag without
-changing the offline contract.
+Online metadata checks are available behind an explicit flag without changing
+the offline contract.
 """
 
 import argparse


### PR DESCRIPTION
## Summary
- Add `/release-governance` as a public academic-writing-toolkit skill for release, rebuttal, artifact, and claim packet governance.
- Add evidence-state schema, release packet templates, and a local `check_release_packet.py` validator.
- Wire the skill into README docs, plugin packaging, plugin checks, and regression tests.

## Test Plan
- `make test`
- `make plugin-check`
- `python3 scripts/audit-public-content.py --base-dir .`
- `rg -n 'VULCA|/Users/yhryzy|TODO|TBD|FIXME|PLACEHOLDER|待补|待定' plugins/academic-writing-toolkit docs README.md`\n- `git diff --check HEAD`\n\n## Notes\n- This is release governance, not experiment governance: the validator only checks packet files, parseability, evidence-state values, required columns, local absolute paths, unresolved markers, and human-final gate fields.\n- Agent/Gemini review remains advisory and cannot promote evidence to `human_final`.\n