### PR TITLE
Add thesis-control workflow

### DIFF
--- a/.agents/skills/thesis-control
+++ b/.agents/skills/thesis-control
@@ -1,0 +1,1 @@
+../../.claude/skills/thesis-control

--- a/.claude/skills/thesis-control/SKILL.md
+++ b/.claude/skills/thesis-control/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: thesis-control
+description: Control AI-assisted thesis edits with spine cards, edit contracts, drift audits, and human gates so manuscript changes stay bounded, reviewable, and reversible.
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# /thesis-control - Thesis Drift Control
+
+## Purpose
+
+Prevent AI-assisted writing from becoming fluent but distorted. Use this before and after substantive thesis edits when the risk is not spelling or style, but loss of author control: widened claims, blurred section purpose, missing caveats, unsynchronised adjacent paragraphs, or local edits that weaken the chapter spine.
+
+## Trigger Words
+
+This skill activates on: `thesis control`, `drift audit`, `edit contract`, `spine card`, `claim drift`, `author control`, `loss of control`, `scope creep`, `rewrite risk`, `/thesis-control`.
+
+## Core Rule
+
+Do not edit thesis prose until the intended change has an explicit contract.
+
+The contract must answer:
+
+```text
+This edit is allowed to change [specific local issue] in [specific unit], while preserving [spine sentence], [scope boundary], [core claims], and [do-not-change items].
+```
+
+If this sentence cannot be written, stop and diagnose the section instead of rewriting it.
+
+## Control Files
+
+Use a `thesis_control/` directory when the project needs durable tracking:
+
+- `spine_cards.csv`
+- `edit_contracts.csv`
+- `drift_audits.csv`
+
+Run the optional validator when Python is available:
+
+```bash
+python {skill_dir}/scripts/check_thesis_control.py <project_root> --strict
+```
+
+The validator checks packet structure and gate consistency. It does not judge scholarly truth.
+
+## Workflow
+
+### 1. Establish Or Read The Spine Card
+
+Before editing a chapter, section, or paragraph cluster, identify:
+
+- unit id
+- source path
+- section title
+- spine sentence
+- scope boundary
+- core claims
+- do-not-change items
+
+The spine sentence should be narrow:
+
+```text
+This unit argues that [specific claim] by showing [specific basis], so the chapter can [specific function].
+```
+
+If the current text does not support a clear spine sentence, produce a diagnosis and ask for author direction before changing prose.
+
+### 2. Create The Edit Contract
+
+For every substantive edit, state:
+
+- target unit and file range
+- change scope
+- allowed changes
+- forbidden changes
+- adjacent context that must be checked
+- acceptance checks
+- whether human approval is required before editing
+
+Always require human approval for:
+
+- changing the section spine
+- adding or broadening claims
+- deleting caveats or limitations
+- moving evidence between sections
+- rewriting more than one paragraph
+- merging or splitting sections
+
+### 3. Apply Only Approved Changes
+
+After approval, edit only the approved scope.
+
+Keep mechanical fixes separate from argument changes. Do not bundle style, structure, evidence, and claim changes into one patch unless the contract explicitly allows it.
+
+### 4. Run The Drift Audit
+
+After editing, compare the new prose against the contract and report:
+
+- changed claims
+- changed boundaries or caveats
+- new unsupported claims
+- deleted evidence anchors
+- missed adjacent updates
+- section-spine change
+- decision: accept, partial accept, revise, or rollback
+
+If any claim, boundary, or caveat changed, the result needs human review even if the prose is smoother.
+
+### 5. Record Human Gate Outcome
+
+The author decides whether to accept, partially accept, revise, or rollback. Do not mark a high-risk edit as accepted without explicit human approval.
+
+## Output Patterns
+
+### Audit Only
+
+Return:
+
+- current spine diagnosis
+- likely drift risks
+- control gaps
+- recommended edit contracts
+- blocked items needing author decision
+
+### Pre-Edit Contract
+
+Return:
+
+```text
+## Edit Contract
+
+Unit:
+Spine sentence:
+Allowed changes:
+Forbidden changes:
+Adjacent context to check:
+Acceptance checks:
+Human approval required:
+Proceed only after approval:
+```
+
+### Post-Edit Drift Audit
+
+Return:
+
+```text
+## Drift Audit
+
+Contract:
+Changed claims:
+Changed boundaries:
+New unsupported claims:
+Missed adjacent updates:
+Decision:
+Human review required:
+Recommended next action:
+```
+
+## Stop Conditions
+
+Stop and ask for author direction if:
+
+- the section spine cannot be stated clearly
+- the requested edit would broaden a claim without evidence
+- a local edit requires adjacent updates outside the approved scope
+- the user asks for a full-chapter rewrite without a spine map
+- previous AI edits cannot be distinguished from author-approved text
+- the edit would remove caveats, limitations, or uncertainty language without explicit approval

--- a/.claude/skills/thesis-control/scripts/check_thesis_control.py
+++ b/.claude/skills/thesis-control/scripts/check_thesis_control.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Validate thesis-control packets.
+
+The checker is intentionally structural. It verifies that a project has
+spine cards, edit contracts, drift audits, and human-gate consistency for
+AI-assisted thesis edits. It does not judge whether the academic argument is
+true or well written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+REQUIRED_FILES = {
+    "spine_cards.csv": [
+        "unit_id",
+        "path",
+        "section_title",
+        "spine_sentence",
+        "scope_boundary",
+        "core_claims",
+        "do_not_change",
+    ],
+    "edit_contracts.csv": [
+        "contract_id",
+        "unit_id",
+        "change_scope",
+        "allowed_changes",
+        "forbidden_changes",
+        "adjacent_context",
+        "acceptance_checks",
+        "human_approved",
+        "status",
+    ],
+    "drift_audits.csv": [
+        "audit_id",
+        "contract_id",
+        "changed_claims",
+        "changed_boundaries",
+        "new_unsupported_claims",
+        "missed_adjacent_updates",
+        "drift_decision",
+        "human_review_required",
+        "status",
+    ],
+}
+
+CONTRACT_STATUSES = {"draft", "approved", "applied", "rejected"}
+DRIFT_DECISIONS = {"accept", "partial_accept", "revise", "rollback"}
+AUDIT_STATUSES = {"passed", "needs_review", "failed"}
+EMPTY_MARKERS = {"", "none", "n/a", "na", "no", "not applicable"}
+
+
+def is_empty(value: str) -> bool:
+    return value.strip().lower() in EMPTY_MARKERS
+
+
+def parse_bool(value: str) -> bool | None:
+    lowered = value.strip().lower()
+    if lowered in {"true", "yes", "y", "1"}:
+        return True
+    if lowered in {"false", "no", "n", "0"}:
+        return False
+    return None
+
+
+def read_csv(path: Path) -> Tuple[List[Dict[str, str]], List[str]]:
+    issues: List[str] = []
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            rows = list(reader)
+    except csv.Error as exc:
+        return [], [f"{path}: CSV parse error: {exc}"]
+    except OSError as exc:
+        return [], [f"{path}: cannot read file: {exc}"]
+
+    if reader.fieldnames is None:
+        return [], [f"{path}: missing header row"]
+
+    return rows, issues
+
+
+def validate_columns(root: Path, filename: str) -> Tuple[List[Dict[str, str]], List[dict]]:
+    path = root / "thesis_control" / filename
+    issues: List[dict] = []
+    if not path.is_file():
+        return [], [{"kind": "missing-file", "location": str(path), "message": f"missing {filename}"}]
+
+    rows, read_issues = read_csv(path)
+    for message in read_issues:
+        issues.append({"kind": "csv-error", "location": str(path), "message": message})
+    if issues:
+        return rows, issues
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+
+    missing = [column for column in REQUIRED_FILES[filename] if column not in fieldnames]
+    for column in missing:
+        issues.append(
+            {
+                "kind": "missing-column",
+                "location": str(path),
+                "message": f"{filename} missing column: {column}",
+            }
+        )
+
+    if not rows:
+        issues.append({"kind": "empty-file", "location": str(path), "message": f"{filename} has no data rows"})
+
+    return rows, issues
+
+
+def row_location(filename: str, index: int) -> str:
+    return f"thesis_control/{filename}:row {index + 2}"
+
+
+def add_issue(issues: List[dict], kind: str, location: str, message: str) -> None:
+    issues.append({"kind": kind, "location": location, "message": message})
+
+
+def validate_packet(root: Path, strict: bool = False) -> dict:
+    issues: List[dict] = []
+    spine_rows, spine_issues = validate_columns(root, "spine_cards.csv")
+    contract_rows, contract_issues = validate_columns(root, "edit_contracts.csv")
+    audit_rows, audit_issues = validate_columns(root, "drift_audits.csv")
+    issues.extend(spine_issues + contract_issues + audit_issues)
+
+    spine_ids = set()
+    for index, row in enumerate(spine_rows):
+        location = row_location("spine_cards.csv", index)
+        unit_id = row.get("unit_id", "").strip()
+        if not unit_id:
+            add_issue(issues, "missing-unit-id", location, "spine card has no unit_id")
+        elif unit_id in spine_ids:
+            add_issue(issues, "duplicate-unit-id", location, f"duplicate unit_id: {unit_id}")
+        else:
+            spine_ids.add(unit_id)
+
+        for column in ["path", "section_title", "spine_sentence", "scope_boundary", "core_claims", "do_not_change"]:
+            if is_empty(row.get(column, "")):
+                add_issue(issues, "empty-spine-field", location, f"spine card field is empty: {column}")
+
+    contract_ids = set()
+    applied_contracts = set()
+    for index, row in enumerate(contract_rows):
+        location = row_location("edit_contracts.csv", index)
+        contract_id = row.get("contract_id", "").strip()
+        unit_id = row.get("unit_id", "").strip()
+        status = row.get("status", "").strip().lower()
+        approved = parse_bool(row.get("human_approved", ""))
+
+        if not contract_id:
+            add_issue(issues, "missing-contract-id", location, "edit contract has no contract_id")
+        elif contract_id in contract_ids:
+            add_issue(issues, "duplicate-contract-id", location, f"duplicate contract_id: {contract_id}")
+        else:
+            contract_ids.add(contract_id)
+
+        if unit_id and unit_id not in spine_ids:
+            add_issue(issues, "unknown-unit-id", location, f"contract references unknown unit_id: {unit_id}")
+
+        if status not in CONTRACT_STATUSES:
+            add_issue(issues, "invalid-contract-status", location, f"invalid contract status: {status}")
+
+        if approved is None:
+            add_issue(issues, "invalid-human-approved", location, "human_approved must be true or false")
+        if status in {"approved", "applied"} and approved is not True:
+            add_issue(issues, "missing-human-approval", location, "approved/applied contracts require human_approved=true")
+
+        for column in ["change_scope", "allowed_changes", "forbidden_changes", "adjacent_context", "acceptance_checks"]:
+            if is_empty(row.get(column, "")):
+                add_issue(issues, "empty-contract-field", location, f"edit contract field is empty: {column}")
+
+        if status == "applied" and contract_id:
+            applied_contracts.add(contract_id)
+
+    audited_contracts = set()
+    for index, row in enumerate(audit_rows):
+        location = row_location("drift_audits.csv", index)
+        contract_id = row.get("contract_id", "").strip()
+        decision = row.get("drift_decision", "").strip().lower()
+        status = row.get("status", "").strip().lower()
+        review_required = parse_bool(row.get("human_review_required", ""))
+        changed_claims = row.get("changed_claims", "")
+        changed_boundaries = row.get("changed_boundaries", "")
+        new_claims = row.get("new_unsupported_claims", "")
+        missed_adjacent = row.get("missed_adjacent_updates", "")
+
+        if contract_id:
+            audited_contracts.add(contract_id)
+            if contract_id not in contract_ids:
+                add_issue(issues, "unknown-contract-id", location, f"audit references unknown contract_id: {contract_id}")
+        else:
+            add_issue(issues, "missing-contract-id", location, "drift audit has no contract_id")
+
+        if decision not in DRIFT_DECISIONS:
+            add_issue(issues, "invalid-drift-decision", location, f"invalid drift_decision: {decision}")
+        if status not in AUDIT_STATUSES:
+            add_issue(issues, "invalid-audit-status", location, f"invalid audit status: {status}")
+        if review_required is None:
+            add_issue(issues, "invalid-human-review-required", location, "human_review_required must be true or false")
+
+        high_risk = any(
+            not is_empty(value)
+            for value in [changed_claims, changed_boundaries, new_claims, missed_adjacent]
+        )
+        if high_risk and review_required is not True:
+            add_issue(issues, "missing-human-review", location, "claim/boundary/adjacent drift requires human_review_required=true")
+        if high_risk and decision == "accept":
+            add_issue(issues, "unsafe-accept", location, "high-risk drift cannot be accepted without revision or partial acceptance")
+        if not is_empty(new_claims) and status == "passed":
+            add_issue(issues, "unsupported-claim-passed", location, "new unsupported claims cannot have status=passed")
+        if not is_empty(missed_adjacent) and status == "passed":
+            add_issue(issues, "missed-adjacent-passed", location, "missed adjacent updates cannot have status=passed")
+
+    if strict:
+        missing_audits = sorted(applied_contracts - audited_contracts)
+        for contract_id in missing_audits:
+            add_issue(
+                issues,
+                "missing-drift-audit",
+                "thesis_control/drift_audits.csv",
+                f"applied contract has no drift audit: {contract_id}",
+            )
+
+    return {
+        "schema_version": 1,
+        "base_dir": str(root),
+        "strict": strict,
+        "summary": {
+            "spine_cards": len(spine_rows),
+            "edit_contracts": len(contract_rows),
+            "drift_audits": len(audit_rows),
+        },
+        "issues": issues,
+        "issue_count": len(issues),
+    }
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate thesis-control spine, contract, and drift-audit files.")
+    parser.add_argument("base_dir", nargs="?", default=".", help="Project root containing thesis_control/")
+    parser.add_argument("--strict", action="store_true", help="Require every applied contract to have a drift audit")
+    parser.add_argument("--json", action="store_true", dest="emit_json", help="Emit JSON output")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path(args.base_dir).resolve()
+    payload = validate_packet(root, strict=args.strict)
+
+    if args.emit_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Thesis-control root: {root}")
+        if payload["issues"]:
+            for issue in payload["issues"]:
+                print(f"- {issue['location']}: {issue['kind']}: {issue['message']}")
+        else:
+            print("- no thesis-control issues detected")
+
+    return 1 if payload["issues"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then open [`examples/demo-project/`](examples/demo-project/) in your agent host 
 ## Workflow
 
 ```
-/read -> /note -> /map -> /evidence-review -> /integrate -> /manuscript-reframe -> /audit -> /release-governance -> /style -> /logic-review -> /export
+/read -> /note -> /map -> /evidence-review -> /integrate -> /thesis-control -> /manuscript-reframe -> /audit -> /release-governance -> /style -> /logic-review -> /export
              |                                      |
              v                                      v
         /verify                               /verify-refs
@@ -87,6 +87,7 @@ Setup guides live in [`docs/setup-claude-code.md`](docs/setup-claude-code.md), [
 | `/map` | Map sources to chapters and coverage gaps |
 | `/evidence-review` | Build evidence-controlled gap maps, claim registers, citation plans, and overclaim audits |
 | `/integrate` | Propose and apply approved note-to-chapter integrations |
+| `/thesis-control` | Keep AI-assisted thesis edits bounded with spine cards, edit contracts, drift audits, and human gates |
 | `/manuscript-reframe` | Turn report-like drafts into paper-form scientific arguments |
 | `/audit` | Check numbers, terminology, cross-references, and citations |
 | `/release-governance` | Prepare release, rebuttal, artifact, and claim packets with ref-artifact-gate controls |
@@ -118,6 +119,7 @@ python3 scripts/verify-refs.py --bib references.bib --json
 python3 scripts/verify-refs.py --bib references.bib --json --online
 python3 scripts/verify-refs.py --bib references.bib --json --online --metadata-dir path/to/metadata-fixtures
 
+python3 .claude/skills/thesis-control/scripts/check_thesis_control.py . --strict
 python3 .claude/skills/release-governance/scripts/check_release_packet.py .
 ```
 

--- a/docs/openai-codex-plugin-submission.md
+++ b/docs/openai-codex-plugin-submission.md
@@ -63,6 +63,7 @@ The manifest follows the OpenAI Codex plugin docs:
 - `map`
 - `evidence-review`
 - `integrate`
+- `thesis-control`
 - `audit`
 - `release-governance`
 - `manuscript-reframe`

--- a/docs/skills/15-thesis-control.md
+++ b/docs/skills/15-thesis-control.md
@@ -1,0 +1,44 @@
+# /thesis-control
+
+Use `/thesis-control` when AI-assisted editing may make a thesis draft smoother but less faithful to the author's intended argument.
+
+## What It Does
+
+- Builds spine cards for chapters, sections, or paragraph clusters.
+- Requires an edit contract before substantive rewriting.
+- Separates mechanical fixes from argument, structure, evidence, and claim changes.
+- Runs a post-edit drift audit for changed claims, changed boundaries, new unsupported claims, and missed adjacent updates.
+- Requires human review for high-risk changes.
+- Provides an optional validator for durable `thesis_control/` packets.
+
+## Control Files
+
+Durable projects can keep:
+
+- `thesis_control/spine_cards.csv`
+- `thesis_control/edit_contracts.csv`
+- `thesis_control/drift_audits.csv`
+
+Validate them with:
+
+```bash
+python3 .claude/skills/thesis-control/scripts/check_thesis_control.py . --strict
+```
+
+## Typical Prompts
+
+```text
+Use /thesis-control before editing this section. Do not modify prose yet.
+```
+
+```text
+Create an edit contract for this paragraph cluster and identify what must not change.
+```
+
+```text
+Run a drift audit on the last edit and tell me whether the change should be accepted, revised, or rolled back.
+```
+
+## Key Guardrail
+
+Do not accept fluent rewritten prose until changed claims, changed boundaries, unsupported additions, and missed adjacent updates have been checked.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -9,7 +9,7 @@ If you want to start from a goal rather than a skill name, see the [use-case gui
 ## Pipeline
 
 ```text
-/read -> /note -> /map -> /evidence-review -> /integrate -> /manuscript-reframe -> /audit -> /release-governance -> /style -> /logic-review -> /export
+/read -> /note -> /map -> /evidence-review -> /integrate -> /thesis-control -> /manuscript-reframe -> /audit -> /release-governance -> /style -> /logic-review -> /export
              |                                      |
              v                                      v
         /verify                               /verify-refs
@@ -30,6 +30,7 @@ If you want to start from a goal rather than a skill name, see the [use-case gui
 | `/map` | [04-map.md](04-map.md) |
 | `/evidence-review` | [12-evidence-review.md](12-evidence-review.md) |
 | `/integrate` | [05-integrate.md](05-integrate.md) |
+| `/thesis-control` | [15-thesis-control.md](15-thesis-control.md) |
 | `/manuscript-reframe` | [14-manuscript-reframe.md](14-manuscript-reframe.md) |
 | `/audit` | [06-audit.md](06-audit.md) |
 | `/release-governance` | [13-release-governance.md](13-release-governance.md) |

--- a/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
+++ b/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name":  "academic-writing-toolkit",
     "version":  "0.3.1",
-    "description":  "Academic reading, thesis writing, manuscript reframing, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, human-evaluation handoff repair, and export skills for Codex.",
+    "description":  "Academic reading, thesis writing, thesis drift control, manuscript reframing, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, human-evaluation handoff repair, and export skills for Codex.",
     "author":  {
                    "name":  "Academic Writing Toolkit Maintainers",
                    "url":  "https://github.com/yha9806"
@@ -22,13 +22,14 @@
                      "human-evaluation",
                      "annotation-repair",
                      "manuscript-reframe",
+                     "thesis-control",
                      "scientific-writing"
                  ],
     "skills":  "./skills/",
     "interface":  {
                       "displayName":  "Academic Writing Toolkit",
-                      "shortDescription":  "Structured research, manuscript reframing, evidence-review, release governance, human-eval repair, citation, style, and export workflows.",
-                      "longDescription":  "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, reframing report-like drafts into scientific manuscripts, integrating arguments, auditing citations and consistency, preparing release-governance packets, validating and repairing human-evaluation handoff packages, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
+                      "shortDescription":  "Structured research, thesis drift control, manuscript reframing, evidence-review, release governance, citation, style, and export workflows.",
+                      "longDescription":  "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, controlling AI-assisted thesis edits with spine cards and drift audits, reframing report-like drafts into scientific manuscripts, integrating arguments, auditing citations and consistency, preparing release-governance packets, validating and repairing human-evaluation handoff packages, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
                       "developerName":  "Academic Writing Toolkit Maintainers",
                       "category":  "Productivity",
                       "capabilities":  [
@@ -41,8 +42,8 @@
                       "termsOfServiceURL":  "https://github.com/yha9806/academic-writing-toolkit/blob/master/docs/terms.md",
                       "defaultPrompt":  [
                                             "Read this paper and extract thesis connections.",
-                                            "Reframe this report-like draft into a scientific manuscript with a clear gap and contribution.",
-                                            "Prepare a release-governance or human-evaluation repair packet."
+                                            "Create an edit contract, drift audit, and reframe plan for this thesis section.",
+                                            "Prepare a release-governance packet."
                                         ],
                       "brandColor":  "#2563EB",
                       "composerIcon":  "./assets/icon.png",

--- a/plugins/academic-writing-toolkit/README.md
+++ b/plugins/academic-writing-toolkit/README.md
@@ -10,6 +10,7 @@ This Codex plugin packages the academic-writing-toolkit skills for structured re
 - `map`: map literature coverage against thesis chapters
 - `evidence-review`: build evidence-controlled literature gap maps, claim registers, citation plans, and overclaim audits
 - `integrate`: integrate completed reading notes into chapter drafts
+- `thesis-control`: keep AI-assisted thesis edits bounded with spine cards, edit contracts, drift audits, and human gates
 - `manuscript-reframe`: turn report-like drafts into paper-form scientific arguments with clear gap, contribution, result narrative, figure/table roles, and submission blockers
 - `audit`: audit citation consistency, numbers, terminology, and cross-references
 - `release-governance`: prepare release, rebuttal, artifact, and claim packets with ref-artifact-gate controls

--- a/plugins/academic-writing-toolkit/skills/thesis-control/SKILL.md
+++ b/plugins/academic-writing-toolkit/skills/thesis-control/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: thesis-control
+description: Control AI-assisted thesis edits with spine cards, edit contracts, drift audits, and human gates so manuscript changes stay bounded, reviewable, and reversible.
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# /thesis-control - Thesis Drift Control
+
+## Purpose
+
+Prevent AI-assisted writing from becoming fluent but distorted. Use this before and after substantive thesis edits when the risk is not spelling or style, but loss of author control: widened claims, blurred section purpose, missing caveats, unsynchronised adjacent paragraphs, or local edits that weaken the chapter spine.
+
+## Trigger Words
+
+This skill activates on: `thesis control`, `drift audit`, `edit contract`, `spine card`, `claim drift`, `author control`, `loss of control`, `scope creep`, `rewrite risk`, `/thesis-control`.
+
+## Core Rule
+
+Do not edit thesis prose until the intended change has an explicit contract.
+
+The contract must answer:
+
+```text
+This edit is allowed to change [specific local issue] in [specific unit], while preserving [spine sentence], [scope boundary], [core claims], and [do-not-change items].
+```
+
+If this sentence cannot be written, stop and diagnose the section instead of rewriting it.
+
+## Control Files
+
+Use a `thesis_control/` directory when the project needs durable tracking:
+
+- `spine_cards.csv`
+- `edit_contracts.csv`
+- `drift_audits.csv`
+
+Run the optional validator when Python is available:
+
+```bash
+python {skill_dir}/scripts/check_thesis_control.py <project_root> --strict
+```
+
+The validator checks packet structure and gate consistency. It does not judge scholarly truth.
+
+## Workflow
+
+### 1. Establish Or Read The Spine Card
+
+Before editing a chapter, section, or paragraph cluster, identify:
+
+- unit id
+- source path
+- section title
+- spine sentence
+- scope boundary
+- core claims
+- do-not-change items
+
+The spine sentence should be narrow:
+
+```text
+This unit argues that [specific claim] by showing [specific basis], so the chapter can [specific function].
+```
+
+If the current text does not support a clear spine sentence, produce a diagnosis and ask for author direction before changing prose.
+
+### 2. Create The Edit Contract
+
+For every substantive edit, state:
+
+- target unit and file range
+- change scope
+- allowed changes
+- forbidden changes
+- adjacent context that must be checked
+- acceptance checks
+- whether human approval is required before editing
+
+Always require human approval for:
+
+- changing the section spine
+- adding or broadening claims
+- deleting caveats or limitations
+- moving evidence between sections
+- rewriting more than one paragraph
+- merging or splitting sections
+
+### 3. Apply Only Approved Changes
+
+After approval, edit only the approved scope.
+
+Keep mechanical fixes separate from argument changes. Do not bundle style, structure, evidence, and claim changes into one patch unless the contract explicitly allows it.
+
+### 4. Run The Drift Audit
+
+After editing, compare the new prose against the contract and report:
+
+- changed claims
+- changed boundaries or caveats
+- new unsupported claims
+- deleted evidence anchors
+- missed adjacent updates
+- section-spine change
+- decision: accept, partial accept, revise, or rollback
+
+If any claim, boundary, or caveat changed, the result needs human review even if the prose is smoother.
+
+### 5. Record Human Gate Outcome
+
+The author decides whether to accept, partially accept, revise, or rollback. Do not mark a high-risk edit as accepted without explicit human approval.
+
+## Output Patterns
+
+### Audit Only
+
+Return:
+
+- current spine diagnosis
+- likely drift risks
+- control gaps
+- recommended edit contracts
+- blocked items needing author decision
+
+### Pre-Edit Contract
+
+Return:
+
+```text
+## Edit Contract
+
+Unit:
+Spine sentence:
+Allowed changes:
+Forbidden changes:
+Adjacent context to check:
+Acceptance checks:
+Human approval required:
+Proceed only after approval:
+```
+
+### Post-Edit Drift Audit
+
+Return:
+
+```text
+## Drift Audit
+
+Contract:
+Changed claims:
+Changed boundaries:
+New unsupported claims:
+Missed adjacent updates:
+Decision:
+Human review required:
+Recommended next action:
+```
+
+## Stop Conditions
+
+Stop and ask for author direction if:
+
+- the section spine cannot be stated clearly
+- the requested edit would broaden a claim without evidence
+- a local edit requires adjacent updates outside the approved scope
+- the user asks for a full-chapter rewrite without a spine map
+- previous AI edits cannot be distinguished from author-approved text
+- the edit would remove caveats, limitations, or uncertainty language without explicit approval

--- a/plugins/academic-writing-toolkit/skills/thesis-control/scripts/check_thesis_control.py
+++ b/plugins/academic-writing-toolkit/skills/thesis-control/scripts/check_thesis_control.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Validate thesis-control packets.
+
+The checker is intentionally structural. It verifies that a project has
+spine cards, edit contracts, drift audits, and human-gate consistency for
+AI-assisted thesis edits. It does not judge whether the academic argument is
+true or well written.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List, Tuple
+
+
+REQUIRED_FILES = {
+    "spine_cards.csv": [
+        "unit_id",
+        "path",
+        "section_title",
+        "spine_sentence",
+        "scope_boundary",
+        "core_claims",
+        "do_not_change",
+    ],
+    "edit_contracts.csv": [
+        "contract_id",
+        "unit_id",
+        "change_scope",
+        "allowed_changes",
+        "forbidden_changes",
+        "adjacent_context",
+        "acceptance_checks",
+        "human_approved",
+        "status",
+    ],
+    "drift_audits.csv": [
+        "audit_id",
+        "contract_id",
+        "changed_claims",
+        "changed_boundaries",
+        "new_unsupported_claims",
+        "missed_adjacent_updates",
+        "drift_decision",
+        "human_review_required",
+        "status",
+    ],
+}
+
+CONTRACT_STATUSES = {"draft", "approved", "applied", "rejected"}
+DRIFT_DECISIONS = {"accept", "partial_accept", "revise", "rollback"}
+AUDIT_STATUSES = {"passed", "needs_review", "failed"}
+EMPTY_MARKERS = {"", "none", "n/a", "na", "no", "not applicable"}
+
+
+def is_empty(value: str) -> bool:
+    return value.strip().lower() in EMPTY_MARKERS
+
+
+def parse_bool(value: str) -> bool | None:
+    lowered = value.strip().lower()
+    if lowered in {"true", "yes", "y", "1"}:
+        return True
+    if lowered in {"false", "no", "n", "0"}:
+        return False
+    return None
+
+
+def read_csv(path: Path) -> Tuple[List[Dict[str, str]], List[str]]:
+    issues: List[str] = []
+    try:
+        with path.open(newline="", encoding="utf-8") as handle:
+            reader = csv.DictReader(handle)
+            rows = list(reader)
+    except csv.Error as exc:
+        return [], [f"{path}: CSV parse error: {exc}"]
+    except OSError as exc:
+        return [], [f"{path}: cannot read file: {exc}"]
+
+    if reader.fieldnames is None:
+        return [], [f"{path}: missing header row"]
+
+    return rows, issues
+
+
+def validate_columns(root: Path, filename: str) -> Tuple[List[Dict[str, str]], List[dict]]:
+    path = root / "thesis_control" / filename
+    issues: List[dict] = []
+    if not path.is_file():
+        return [], [{"kind": "missing-file", "location": str(path), "message": f"missing {filename}"}]
+
+    rows, read_issues = read_csv(path)
+    for message in read_issues:
+        issues.append({"kind": "csv-error", "location": str(path), "message": message})
+    if issues:
+        return rows, issues
+
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        fieldnames = reader.fieldnames or []
+
+    missing = [column for column in REQUIRED_FILES[filename] if column not in fieldnames]
+    for column in missing:
+        issues.append(
+            {
+                "kind": "missing-column",
+                "location": str(path),
+                "message": f"{filename} missing column: {column}",
+            }
+        )
+
+    if not rows:
+        issues.append({"kind": "empty-file", "location": str(path), "message": f"{filename} has no data rows"})
+
+    return rows, issues
+
+
+def row_location(filename: str, index: int) -> str:
+    return f"thesis_control/{filename}:row {index + 2}"
+
+
+def add_issue(issues: List[dict], kind: str, location: str, message: str) -> None:
+    issues.append({"kind": kind, "location": location, "message": message})
+
+
+def validate_packet(root: Path, strict: bool = False) -> dict:
+    issues: List[dict] = []
+    spine_rows, spine_issues = validate_columns(root, "spine_cards.csv")
+    contract_rows, contract_issues = validate_columns(root, "edit_contracts.csv")
+    audit_rows, audit_issues = validate_columns(root, "drift_audits.csv")
+    issues.extend(spine_issues + contract_issues + audit_issues)
+
+    spine_ids = set()
+    for index, row in enumerate(spine_rows):
+        location = row_location("spine_cards.csv", index)
+        unit_id = row.get("unit_id", "").strip()
+        if not unit_id:
+            add_issue(issues, "missing-unit-id", location, "spine card has no unit_id")
+        elif unit_id in spine_ids:
+            add_issue(issues, "duplicate-unit-id", location, f"duplicate unit_id: {unit_id}")
+        else:
+            spine_ids.add(unit_id)
+
+        for column in ["path", "section_title", "spine_sentence", "scope_boundary", "core_claims", "do_not_change"]:
+            if is_empty(row.get(column, "")):
+                add_issue(issues, "empty-spine-field", location, f"spine card field is empty: {column}")
+
+    contract_ids = set()
+    applied_contracts = set()
+    for index, row in enumerate(contract_rows):
+        location = row_location("edit_contracts.csv", index)
+        contract_id = row.get("contract_id", "").strip()
+        unit_id = row.get("unit_id", "").strip()
+        status = row.get("status", "").strip().lower()
+        approved = parse_bool(row.get("human_approved", ""))
+
+        if not contract_id:
+            add_issue(issues, "missing-contract-id", location, "edit contract has no contract_id")
+        elif contract_id in contract_ids:
+            add_issue(issues, "duplicate-contract-id", location, f"duplicate contract_id: {contract_id}")
+        else:
+            contract_ids.add(contract_id)
+
+        if unit_id and unit_id not in spine_ids:
+            add_issue(issues, "unknown-unit-id", location, f"contract references unknown unit_id: {unit_id}")
+
+        if status not in CONTRACT_STATUSES:
+            add_issue(issues, "invalid-contract-status", location, f"invalid contract status: {status}")
+
+        if approved is None:
+            add_issue(issues, "invalid-human-approved", location, "human_approved must be true or false")
+        if status in {"approved", "applied"} and approved is not True:
+            add_issue(issues, "missing-human-approval", location, "approved/applied contracts require human_approved=true")
+
+        for column in ["change_scope", "allowed_changes", "forbidden_changes", "adjacent_context", "acceptance_checks"]:
+            if is_empty(row.get(column, "")):
+                add_issue(issues, "empty-contract-field", location, f"edit contract field is empty: {column}")
+
+        if status == "applied" and contract_id:
+            applied_contracts.add(contract_id)
+
+    audited_contracts = set()
+    for index, row in enumerate(audit_rows):
+        location = row_location("drift_audits.csv", index)
+        contract_id = row.get("contract_id", "").strip()
+        decision = row.get("drift_decision", "").strip().lower()
+        status = row.get("status", "").strip().lower()
+        review_required = parse_bool(row.get("human_review_required", ""))
+        changed_claims = row.get("changed_claims", "")
+        changed_boundaries = row.get("changed_boundaries", "")
+        new_claims = row.get("new_unsupported_claims", "")
+        missed_adjacent = row.get("missed_adjacent_updates", "")
+
+        if contract_id:
+            audited_contracts.add(contract_id)
+            if contract_id not in contract_ids:
+                add_issue(issues, "unknown-contract-id", location, f"audit references unknown contract_id: {contract_id}")
+        else:
+            add_issue(issues, "missing-contract-id", location, "drift audit has no contract_id")
+
+        if decision not in DRIFT_DECISIONS:
+            add_issue(issues, "invalid-drift-decision", location, f"invalid drift_decision: {decision}")
+        if status not in AUDIT_STATUSES:
+            add_issue(issues, "invalid-audit-status", location, f"invalid audit status: {status}")
+        if review_required is None:
+            add_issue(issues, "invalid-human-review-required", location, "human_review_required must be true or false")
+
+        high_risk = any(
+            not is_empty(value)
+            for value in [changed_claims, changed_boundaries, new_claims, missed_adjacent]
+        )
+        if high_risk and review_required is not True:
+            add_issue(issues, "missing-human-review", location, "claim/boundary/adjacent drift requires human_review_required=true")
+        if high_risk and decision == "accept":
+            add_issue(issues, "unsafe-accept", location, "high-risk drift cannot be accepted without revision or partial acceptance")
+        if not is_empty(new_claims) and status == "passed":
+            add_issue(issues, "unsupported-claim-passed", location, "new unsupported claims cannot have status=passed")
+        if not is_empty(missed_adjacent) and status == "passed":
+            add_issue(issues, "missed-adjacent-passed", location, "missed adjacent updates cannot have status=passed")
+
+    if strict:
+        missing_audits = sorted(applied_contracts - audited_contracts)
+        for contract_id in missing_audits:
+            add_issue(
+                issues,
+                "missing-drift-audit",
+                "thesis_control/drift_audits.csv",
+                f"applied contract has no drift audit: {contract_id}",
+            )
+
+    return {
+        "schema_version": 1,
+        "base_dir": str(root),
+        "strict": strict,
+        "summary": {
+            "spine_cards": len(spine_rows),
+            "edit_contracts": len(contract_rows),
+            "drift_audits": len(audit_rows),
+        },
+        "issues": issues,
+        "issue_count": len(issues),
+    }
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate thesis-control spine, contract, and drift-audit files.")
+    parser.add_argument("base_dir", nargs="?", default=".", help="Project root containing thesis_control/")
+    parser.add_argument("--strict", action="store_true", help="Require every applied contract to have a drift audit")
+    parser.add_argument("--json", action="store_true", dest="emit_json", help="Emit JSON output")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    root = Path(args.base_dir).resolve()
+    payload = validate_packet(root, strict=args.strict)
+
+    if args.emit_json:
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Thesis-control root: {root}")
+        if payload["issues"]:
+            for issue in payload["issues"]:
+                print(f"- {issue['location']}: {issue['kind']}: {issue['message']}")
+        else:
+            print("- no thesis-control issues detected")
+
+    return 1 if payload["issues"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-plugin.sh
+++ b/scripts/check-plugin.sh
@@ -135,7 +135,7 @@ if grep -R "\[TODO\]\|TODO:" "$PLUGIN_ROOT" "$MARKETPLACE_JSON" >/dev/null; then
     die "plugin package contains TODO placeholders"
 fi
 
-for skill in audit evidence-review export human-eval-handoff-repair integrate logic-review manuscript-reframe map note progress read release-governance style verify verify-refs; do
+for skill in audit evidence-review export human-eval-handoff-repair integrate logic-review manuscript-reframe map note progress read release-governance style thesis-control verify verify-refs; do
     [[ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]] || die "missing plugin skill: $skill"
 done
 
@@ -146,5 +146,6 @@ done
 "$PYTHON_BIN" "$PLUGIN_ROOT/skills/export/scripts/convert_to_docx.py" --help >/dev/null
 "$PYTHON_BIN" "$PLUGIN_ROOT/skills/evidence-review/scripts/check_review_package.py" --help >/dev/null
 "$PYTHON_BIN" "$PLUGIN_ROOT/skills/release-governance/scripts/check_release_packet.py" --help >/dev/null
+"$PYTHON_BIN" "$PLUGIN_ROOT/skills/thesis-control/scripts/check_thesis_control.py" --help >/dev/null
 
 ok "plugin package validates"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# scripts/test.sh — runs the regression test suite (60 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX + T61-T63 productization) for academic-writing-toolkit.
+# scripts/test.sh — runs the regression test suite (62 automated tests: T2-T18 toolkit + T19-T32 citation/env + T33-T44 public toolkit features + T45-T49 reference metadata + T50-T53 plugin packaging + T54-T58 release governance + T59 docs consistency + T60 Markdown BibTeX + T61-T63 productization + T64-T65 thesis control) for academic-writing-toolkit.
 # Self-contained; saves and restores any state it mutates.
 # Exit 0 if all tests pass, 1 if any fail. CI-suitable.
 # Note: pipefail is intentionally NOT enabled. Several tests assert that a
@@ -725,6 +725,55 @@ if missing:
 PY
 }
 
+_make_valid_thesis_control_packet() {
+    local tmp="$1"
+    mkdir -p "$tmp/thesis_control" "$tmp/chapters"
+    cat > "$tmp/chapters/ch02.md" <<'EOF'
+# Chapter 2
+
+Local-first writing workflows can make source notes inspectable, but this section only claims that file-based records improve traceability within one project. It does not claim that such workflows improve scholarly quality by themselves.
+EOF
+    cat > "$tmp/thesis_control/spine_cards.csv" <<'EOF'
+unit_id,path,section_title,spine_sentence,scope_boundary,core_claims,do_not_change
+ch02-s1,chapters/ch02.md,Local workflow control,This unit argues that file-based records improve traceability within one writing project by keeping notes and claims inspectable.,single-project workflow traceability only,file-based records improve traceability;the workflow does not prove scholarly quality,do not claim quality improvement;preserve single-project boundary
+EOF
+    cat > "$tmp/thesis_control/edit_contracts.csv" <<'EOF'
+contract_id,unit_id,change_scope,allowed_changes,forbidden_changes,adjacent_context,acceptance_checks,human_approved,status
+ec-001,ch02-s1,clarify topic sentence in first paragraph,make the traceability claim clearer without changing its scope,do not add quality improvement claims;do not remove single-project boundary,check following paragraph for repeated boundary language,spine sentence preserved;no new unsupported claim,true,applied
+EOF
+    cat > "$tmp/thesis_control/drift_audits.csv" <<'EOF'
+audit_id,contract_id,changed_claims,changed_boundaries,new_unsupported_claims,missed_adjacent_updates,drift_decision,human_review_required,status
+da-001,ec-001,none,none,none,none,accept,false,passed
+EOF
+}
+
+test_T64() {
+    local tmp out
+    tmp=$(mktemp -d) || return 1
+    _make_valid_thesis_control_packet "$tmp"
+    out=$(python3 .claude/skills/thesis-control/scripts/check_thesis_control.py "$tmp" --strict --json) || {
+        rm -rf "$tmp"
+        return 1
+    }
+    rm -rf "$tmp"
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d['issue_count'] == 0 and d['summary']['edit_contracts'] == 1"
+}
+
+test_T65() {
+    local tmp out rc
+    tmp=$(mktemp -d) || return 1
+    _make_valid_thesis_control_packet "$tmp"
+    cat > "$tmp/thesis_control/drift_audits.csv" <<'EOF'
+audit_id,contract_id,changed_claims,changed_boundaries,new_unsupported_claims,missed_adjacent_updates,drift_decision,human_review_required,status
+da-001,ec-001,The edit now claims the workflow improves final thesis quality,The boundary moved from one project to all thesis writing,workflow improves final thesis quality,related caution paragraph still says quality is not proven,accept,false,passed
+EOF
+    out=$(python3 .claude/skills/thesis-control/scripts/check_thesis_control.py "$tmp" --strict --json 2>&1)
+    rc=$?
+    rm -rf "$tmp"
+    [[ "$rc" -eq 1 ]] || return 1
+    echo "$out" | python3 -c "import json,sys; d=json.load(sys.stdin); kinds={i['kind'] for i in d['issues']}; assert {'missing-human-review','unsafe-accept','unsupported-claim-passed','missed-adjacent-passed'} <= kinds"
+}
+
 test_T50() {
     bash scripts/sync-plugin.sh --check >/dev/null
 }
@@ -939,6 +988,8 @@ run_test "T60 verify-refs accepts Markdown BibTeX fences" test_T60
 run_test "T61 productization docs and demo structure exist" test_T61
 run_test "T62 demo project validates with existing checkers" test_T62
 run_test "T63 productization docs keep local links valid" test_T63
+run_test "T64 thesis-control packet accepts bounded edit case" test_T64
+run_test "T65 thesis-control catches distorted edit case" test_T65
 
 header ""
 if [[ ${#FAIL_LIST[@]} -eq 0 ]]; then


### PR DESCRIPTION
## Summary
- Add the /thesis-control skill for spine cards, edit contracts, drift audits, and human gates.
- Add check_thesis_control.py to validate durable thesis_control packets.
- Add docs, plugin packaging, and CI regression coverage for bounded and distorted edit cases.

## Verification
- make doctor
- make plugin-check
- make chatgpt-app-check
- make test (62 tests, including T64/T65 thesis-control cases)
- git diff --cached --check

## Notes
The checker is structural. It validates control files and gate consistency, but does not judge scholarly truth or replace author review.