### PR TITLE
[codex] Add revision escalation skill

### DIFF
--- a/.agents/skills/revision-escalation
+++ b/.agents/skills/revision-escalation
@@ -1,0 +1,1 @@
+../../.claude/skills/revision-escalation

--- a/.claude/skills/revision-escalation/SKILL.md
+++ b/.claude/skills/revision-escalation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: revision-escalation
+description: Stop repeated failed writing, coding, manuscript, rebuttal, or restructuring revisions when the same issue has gone through 3+ unsatisfactory edits, vague feedback such as still wrong/weird/unclear/weak/越改越乱, version contamination, or possible gap/claim/evidence/venue-fit drift.
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# /revision-escalation - 3-Strike Revision Control
+
+## Purpose
+
+Prevent repeated local patches from making a draft or code path more inconsistent. Use this when the issue may no longer be wording or implementation detail, but specification, structure, evidence, or version-control drift.
+
+## Trigger Words
+
+This skill activates on: `revision escalation`, `3-strike`, `three strikes`, `stop and diagnose`, `still wrong`, `still weird`, `unclear`, `weak`, `越改越乱`, `还是不对`, `还是怪`, `不够清楚`, `逻辑还是混乱`, `/revision-escalation`.
+
+## Core Rule
+
+If the same issue remains unresolved after 3 revision attempts, treat it as a specification or structure problem before treating it as another local editing task.
+
+Do not make a fourth patch immediately.
+
+## Revision Escalation Check
+
+Before editing again, classify the problem:
+
+| Category | Meaning | Next action |
+| --- | --- | --- |
+| Underspecified request | Target, constraint, audience, venue, or expected output is missing. | Ask for a concrete target before editing. |
+| Ambiguous feedback | Feedback is evaluative but not operational: "weird", "weak", "unclear", "not good enough". | Ask what should change. |
+| Local execution problem | The goal is clear, but the previous patch implemented it incorrectly. | Make one small targeted patch. |
+| Structural mismatch | The issue affects the research question, gap, contribution, evidence chain, section structure, module boundary, or venue framing. | Propose a restructure plan before editing. |
+| Evidence gap | The desired claim is unsupported by available data, experiments, citations, or files. | Downgrade the claim or request evidence. |
+| Version contamination | Repeated patches have mixed old assumptions with new requirements, causing inconsistency, duplication, or bloat. | Recommend a new version, branch, or consolidated brief. |
+
+## Required Response
+
+When triggered, respond in this structure before any patch:
+
+```md
+I should pause before making another patch.
+
+This issue has already gone through several revision rounds and may not be a local wording or implementation problem anymore.
+
+Current diagnosis:
+
+* Category:
+* Why:
+* What is missing or conflicting:
+* Recommended next action:
+
+Options:
+A. Clarify the concrete target and continue a local patch.
+B. Consolidate all current requirements into a single brief, then retry.
+C. Create a new version or branch and restructure the section/module.
+D. Reframe the paper/project from the research question, gap, and evidence chain.
+```
+
+## Academic Writing Rule
+
+Classify manuscript work before editing:
+
+- Local patch: wording, grammar, citation format, figure caption, table formatting, or one paragraph.
+- Section-level restructure: one section changes, but the research question, contribution, and evidence chain stay stable.
+- Full reframing: title, abstract, introduction, research question, gap, contribution, methods-results alignment, discussion, or venue framing changes.
+
+For full reframing, do not directly rewrite the manuscript. First produce a reframing brief with target venue, research question, gap, core claim, available evidence, claims that must not be made, and proposed new structure.
+
+## Red Flags
+
+Stop and diagnose when thinking:
+
+- "One more patch should fix it."
+- "The user is still dissatisfied, but I can just rewrite harder."
+- "The wording is awkward" while the evidence chain or contribution boundary is unstable.
+- "The current version is messy, but I can keep accumulating edits."
+
+Never continue accumulating edits on a structurally inconsistent manuscript, rebuttal, or code path.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ The repository also includes a small public-safe multi-case writing-control fixt
         /progress
 
 /human-eval-handoff-repair supports evaluation-package QC and annotation repair workflows.
+/revision-escalation supports 3-strike stop-and-diagnose checks for repeated failed revisions.
 ```
 
 ## Quick Start
@@ -91,6 +92,7 @@ Setup guides live in [`docs/setup-claude-code.md`](docs/setup-claude-code.md), [
 | `/integrate` | Propose and apply approved note-to-chapter integrations |
 | `/thesis-control` | Keep AI-assisted thesis edits bounded with spine cards, edit contracts, drift audits, and human gates |
 | `/manuscript-reframe` | Turn report-like drafts into paper-form scientific arguments |
+| `/revision-escalation` | Stop repeated failed revisions and diagnose whether the issue is specification, structure, evidence, or version contamination |
 | `/audit` | Check numbers, terminology, cross-references, and citations |
 | `/release-governance` | Prepare release, rebuttal, artifact, and claim packets with ref-artifact-gate controls |
 | `/style` | Check and safely fix British English spellings |

--- a/docs/openai-codex-plugin-submission.md
+++ b/docs/openai-codex-plugin-submission.md
@@ -67,6 +67,7 @@ The manifest follows the OpenAI Codex plugin docs:
 - `audit`
 - `release-governance`
 - `manuscript-reframe`
+- `revision-escalation`
 - `style`
 - `logic-review`
 - `verify-refs`

--- a/docs/skills/16-revision-escalation.md
+++ b/docs/skills/16-revision-escalation.md
@@ -1,0 +1,37 @@
+# /revision-escalation
+
+Use `/revision-escalation` when the same writing, code, rebuttal, or manuscript issue has gone through repeated unsatisfactory edits and may no longer be a local patch problem.
+
+## What It Does
+
+- Stops the fourth patch after three failed revision attempts.
+- Classifies the failure as underspecified request, ambiguous feedback, local execution problem, structural mismatch, evidence gap, or version contamination.
+- Separates local wording fixes from section restructuring and full reframing.
+- Forces unsupported claims to be downgraded or backed with evidence before revision continues.
+- Recommends a consolidated brief, new version, or branch when repeated patches have polluted the draft.
+
+## Typical Prompts
+
+```text
+Use /revision-escalation. This gap paragraph has been revised three times and still feels wrong.
+```
+
+```text
+Stop editing and diagnose whether this is a local patch, section restructure, or full reframing problem.
+```
+
+```text
+The rebuttal keeps getting longer but not clearer. Run the 3-strike revision check before another rewrite.
+```
+
+## Expected Output
+
+- category
+- reason for the diagnosis
+- missing or conflicting information
+- recommended next action
+- options for clarifying, consolidating, branching, restructuring, or reframing
+
+## Key Guardrail
+
+Do not continue accumulating edits on a structurally inconsistent manuscript, rebuttal, or code path. If a claim cannot be supported by the available evidence, downgrade it or request evidence before rewriting.

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -18,6 +18,7 @@ If you want to start from a goal rather than a skill name, see the [use-case gui
         /progress
 
 /human-eval-handoff-repair is an evaluation-package QC and annotation repair workflow outside the thesis-writing pipeline.
+/revision-escalation is a 3-strike stop-and-diagnose workflow for repeated failed writing, coding, rebuttal, or manuscript revisions.
 ```
 
 ## Guides
@@ -32,6 +33,7 @@ If you want to start from a goal rather than a skill name, see the [use-case gui
 | `/integrate` | [05-integrate.md](05-integrate.md) |
 | `/thesis-control` | [15-thesis-control.md](15-thesis-control.md) |
 | `/manuscript-reframe` | [14-manuscript-reframe.md](14-manuscript-reframe.md) |
+| `/revision-escalation` | [16-revision-escalation.md](16-revision-escalation.md) |
 | `/audit` | [06-audit.md](06-audit.md) |
 | `/release-governance` | [13-release-governance.md](13-release-governance.md) |
 | `/progress` | [07-progress.md](07-progress.md) |

--- a/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
+++ b/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
     "name":  "academic-writing-toolkit",
     "version":  "0.3.2",
-    "description":  "Academic reading, thesis writing, thesis drift control, manuscript reframing, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, human-evaluation handoff repair, and export skills for Codex.",
+    "description":  "Academic reading, thesis writing, thesis drift control, manuscript reframing, revision escalation, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, human-evaluation handoff repair, and export skills for Codex.",
     "author":  {
                    "name":  "Academic Writing Toolkit Maintainers",
                    "url":  "https://github.com/yha9806"
@@ -22,14 +22,15 @@
                      "human-evaluation",
                      "annotation-repair",
                      "manuscript-reframe",
+                     "revision-escalation",
                      "thesis-control",
                      "scientific-writing"
                  ],
     "skills":  "./skills/",
     "interface":  {
                       "displayName":  "Academic Writing Toolkit",
-                      "shortDescription":  "Structured research, thesis drift control, manuscript reframing, evidence-review, release governance, citation, style, and export workflows.",
-                      "longDescription":  "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, controlling AI-assisted thesis edits with spine cards and drift audits, reframing report-like drafts into scientific manuscripts, integrating arguments, auditing citations and consistency, preparing release-governance packets, validating and repairing human-evaluation handoff packages, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
+                      "shortDescription":  "Structured research, thesis drift control, manuscript reframing, revision escalation, evidence-review, release governance, citation, style, and export workflows.",
+                      "longDescription":  "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, controlling AI-assisted thesis edits with spine cards and drift audits, reframing report-like drafts into scientific manuscripts, stopping repeated failed revisions for diagnosis before more patches, integrating arguments, auditing citations and consistency, preparing release-governance packets, validating and repairing human-evaluation handoff packages, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
                       "developerName":  "Academic Writing Toolkit Maintainers",
                       "category":  "Productivity",
                       "capabilities":  [

--- a/plugins/academic-writing-toolkit/README.md
+++ b/plugins/academic-writing-toolkit/README.md
@@ -12,6 +12,7 @@ This Codex plugin packages the academic-writing-toolkit skills for structured re
 - `integrate`: integrate completed reading notes into chapter drafts
 - `thesis-control`: keep AI-assisted thesis edits bounded with spine cards, edit contracts, drift audits, human gates, and draft packet scaffolding
 - `manuscript-reframe`: turn report-like drafts into paper-form scientific arguments with clear gap, contribution, result narrative, figure/table roles, and submission blockers
+- `revision-escalation`: stop repeated failed revisions and diagnose specification, structure, evidence, or version-contamination problems
 - `audit`: audit citation consistency, numbers, terminology, and cross-references
 - `release-governance`: prepare release, rebuttal, artifact, and claim packets with ref-artifact-gate controls
 - `style`: check and safely fix common US spellings when British English is required

--- a/plugins/academic-writing-toolkit/skills/revision-escalation/SKILL.md
+++ b/plugins/academic-writing-toolkit/skills/revision-escalation/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: revision-escalation
+description: Stop repeated failed writing, coding, manuscript, rebuttal, or restructuring revisions when the same issue has gone through 3+ unsatisfactory edits, vague feedback such as still wrong/weird/unclear/weak/越改越乱, version contamination, or possible gap/claim/evidence/venue-fit drift.
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+# /revision-escalation - 3-Strike Revision Control
+
+## Purpose
+
+Prevent repeated local patches from making a draft or code path more inconsistent. Use this when the issue may no longer be wording or implementation detail, but specification, structure, evidence, or version-control drift.
+
+## Trigger Words
+
+This skill activates on: `revision escalation`, `3-strike`, `three strikes`, `stop and diagnose`, `still wrong`, `still weird`, `unclear`, `weak`, `越改越乱`, `还是不对`, `还是怪`, `不够清楚`, `逻辑还是混乱`, `/revision-escalation`.
+
+## Core Rule
+
+If the same issue remains unresolved after 3 revision attempts, treat it as a specification or structure problem before treating it as another local editing task.
+
+Do not make a fourth patch immediately.
+
+## Revision Escalation Check
+
+Before editing again, classify the problem:
+
+| Category | Meaning | Next action |
+| --- | --- | --- |
+| Underspecified request | Target, constraint, audience, venue, or expected output is missing. | Ask for a concrete target before editing. |
+| Ambiguous feedback | Feedback is evaluative but not operational: "weird", "weak", "unclear", "not good enough". | Ask what should change. |
+| Local execution problem | The goal is clear, but the previous patch implemented it incorrectly. | Make one small targeted patch. |
+| Structural mismatch | The issue affects the research question, gap, contribution, evidence chain, section structure, module boundary, or venue framing. | Propose a restructure plan before editing. |
+| Evidence gap | The desired claim is unsupported by available data, experiments, citations, or files. | Downgrade the claim or request evidence. |
+| Version contamination | Repeated patches have mixed old assumptions with new requirements, causing inconsistency, duplication, or bloat. | Recommend a new version, branch, or consolidated brief. |
+
+## Required Response
+
+When triggered, respond in this structure before any patch:
+
+```md
+I should pause before making another patch.
+
+This issue has already gone through several revision rounds and may not be a local wording or implementation problem anymore.
+
+Current diagnosis:
+
+* Category:
+* Why:
+* What is missing or conflicting:
+* Recommended next action:
+
+Options:
+A. Clarify the concrete target and continue a local patch.
+B. Consolidate all current requirements into a single brief, then retry.
+C. Create a new version or branch and restructure the section/module.
+D. Reframe the paper/project from the research question, gap, and evidence chain.
+```
+
+## Academic Writing Rule
+
+Classify manuscript work before editing:
+
+- Local patch: wording, grammar, citation format, figure caption, table formatting, or one paragraph.
+- Section-level restructure: one section changes, but the research question, contribution, and evidence chain stay stable.
+- Full reframing: title, abstract, introduction, research question, gap, contribution, methods-results alignment, discussion, or venue framing changes.
+
+For full reframing, do not directly rewrite the manuscript. First produce a reframing brief with target venue, research question, gap, core claim, available evidence, claims that must not be made, and proposed new structure.
+
+## Red Flags
+
+Stop and diagnose when thinking:
+
+- "One more patch should fix it."
+- "The user is still dissatisfied, but I can just rewrite harder."
+- "The wording is awkward" while the evidence chain or contribution boundary is unstable.
+- "The current version is messy, but I can keep accumulating edits."
+
+Never continue accumulating edits on a structurally inconsistent manuscript, rebuttal, or code path.

--- a/scripts/check-plugin.sh
+++ b/scripts/check-plugin.sh
@@ -135,7 +135,7 @@ if grep -R "\[TODO\]\|TODO:" "$PLUGIN_ROOT" "$MARKETPLACE_JSON" >/dev/null; then
     die "plugin package contains TODO placeholders"
 fi
 
-for skill in audit evidence-review export human-eval-handoff-repair integrate logic-review manuscript-reframe map note progress read release-governance style thesis-control verify verify-refs; do
+for skill in audit evidence-review export human-eval-handoff-repair integrate logic-review manuscript-reframe map note progress read release-governance revision-escalation style thesis-control verify verify-refs; do
     [[ -f "$PLUGIN_ROOT/skills/$skill/SKILL.md" ]] || die "missing plugin skill: $skill"
 done
 


### PR DESCRIPTION
## Summary

- Add `/revision-escalation`, a 3-strike stop-and-diagnose skill for repeated failed writing, coding, rebuttal, and manuscript revisions.
- Add the Codex/Gemini discovery symlink entry, public skill guide, README/index updates, plugin metadata, and synced plugin skill copy.
- Extend `scripts/check-plugin.sh` so the packaged plugin validates that the new skill is present.

## Validation

- `scripts/check-plugin.sh`
- `quick_validate.py .claude/skills/revision-escalation`
- `quick_validate.py plugins/academic-writing-toolkit/skills/revision-escalation`
- `git diff --cached --check`

## Notes

- The `.agents/skills/revision-escalation` entry is committed as a Git symlink (`120000`) matching the existing skill discovery pattern.
- A Gemini diff-review attempt did not receive the diff from the local CLI, so it was not treated as valid review evidence.