### PR TITLE
Release AWT plugin and ChatGPT App 0.5.0rc4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,24 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - run: make mvp-test
       - run: make mvp-install-check
+
+  plugin-app:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/chatgpt-academic-writing-toolkit/package-lock.json
+      - name: Install plugin helper dependencies
+        run: pip install python-docx markdown
+      - name: Install ChatGPT App dependencies
+        run: npm ci --prefix apps/chatgpt-academic-writing-toolkit
+      - run: make plugin-check
+      - run: make chatgpt-app-check
+      - name: Audit production dependencies
+        run: npm audit --prefix apps/chatgpt-academic-writing-toolkit --omit=dev --audit-level=high

--- a/apps/chatgpt-academic-writing-toolkit/README.md
+++ b/apps/chatgpt-academic-writing-toolkit/README.md
@@ -2,6 +2,11 @@
 
 Tool-only ChatGPT App MCP server for academic writing checks.
 
+This surface is intentionally smaller than the local Workbench and the 20-skill Codex
+companion. It accepts text supplied in ChatGPT and exposes five deterministic tools. It
+does not discover local files, run the Workbench agent, or reproduce the Workbench's
+five end-to-end review workflows.
+
 ## Tools
 
 - `audit_citations`: checks pasted chapter text against pasted reading-note source lines.
@@ -10,7 +15,10 @@ Tool-only ChatGPT App MCP server for academic writing checks.
 - `verify_bibtex_references`: validates pasted BibTeX records offline.
 - `create_reading_note_template`: creates the standard reading-notes Markdown scaffold.
 
-The server processes user-provided text through temporary files only. It does not read local thesis files, persist user submissions, authenticate users, or call external metadata APIs.
+The server processes user-provided text through temporary files only. It does not read
+local thesis files, persist user submissions, authenticate users, or call external
+metadata APIs. HTTP request bodies are capped at 1 MiB; the advertised single-text input
+limit is covered by that cap.
 
 ## Local Development
 
@@ -37,6 +45,10 @@ docker run --rm -p 3000:3000 academic-writing-toolkit-chatgpt-app
 
 ## Submission
 
-OpenAI app review requires a public HTTPS MCP URL, not a local endpoint. Deploy this app to a public host, then submit the hosted `/mcp` URL through OpenAI Platform Apps Manage.
+OpenAI plugin review requires a public HTTPS MCP URL, not a local endpoint. Deploy
+this app to a public host, scan it, and submit the hosted `/mcp` URL through the
+[OpenAI Plugins portal](https://platform.openai.com/plugins).
 
-The review import file is `chatgpt-app-submission.json`.
+`chatgpt-app-submission.json` is the checked source for the five positive and
+three negative tests and tool-annotation justifications. Copy and verify those
+values in the portal; do not assume the portal supports JSON import.

--- a/apps/chatgpt-academic-writing-toolkit/package-lock.json
+++ b/apps/chatgpt-academic-writing-toolkit/package-lock.json
@@ -1,37 +1,37 @@
 {
   "name": "chatgpt-academic-writing-toolkit",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-academic-writing-toolkit",
-      "version": "0.4.0",
+      "version": "0.5.0-rc.4",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.23.0",
-        "express": "^5.1.0",
-        "zod": "^4.1.12"
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "express": "^5.2.1",
+        "zod": "^4.4.3"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -112,21 +112,34 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -433,9 +446,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -570,9 +583,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.18",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.18.tgz",
-      "integrity": "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/apps/chatgpt-academic-writing-toolkit/package.json
+++ b/apps/chatgpt-academic-writing-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-academic-writing-toolkit",
-  "version": "0.4.0",
+  "version": "0.5.0-rc.4",
   "private": true,
   "type": "module",
   "description": "Tool-only ChatGPT App MCP server for academic writing checks.",
@@ -9,8 +9,8 @@
     "start": "node src/server.js"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.23.0",
-    "express": "^5.1.0",
-    "zod": "^4.1.12"
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "express": "^5.2.1",
+    "zod": "^4.4.3"
   }
 }

--- a/apps/chatgpt-academic-writing-toolkit/src/server.js
+++ b/apps/chatgpt-academic-writing-toolkit/src/server.js
@@ -1,9 +1,13 @@
 import { readFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
-import { createMcpExpressApp } from "@modelcontextprotocol/sdk/server/express.js";
+import {
+  hostHeaderValidation,
+  localhostHostValidation,
+} from "@modelcontextprotocol/sdk/server/middleware/hostHeaderValidation.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import express from "express";
 
 import { TOOL_DEFINITIONS } from "./tool-definitions.js";
 import {
@@ -17,6 +21,7 @@ import {
 const APP_NAME = "academic-writing-toolkit";
 const APP_PACKAGE = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8"));
 const APP_VERSION = APP_PACKAGE.version;
+export const MAX_REQUEST_BYTES = 1_048_576;
 
 const TOOL_HANDLERS = {
   audit_citations: auditCitations,
@@ -72,8 +77,17 @@ function methodNotAllowed(_req, res) {
   });
 }
 
-export function createHttpApp({ host = process.env.HOST || "127.0.0.1" } = {}) {
-  const app = createMcpExpressApp({ host });
+export function createHttpApp({
+  host = process.env.HOST || "127.0.0.1",
+  allowedHosts,
+} = {}) {
+  const app = express();
+  app.use(express.json({ limit: MAX_REQUEST_BYTES }));
+  if (allowedHosts?.length) {
+    app.use(hostHeaderValidation(allowedHosts));
+  } else if (["127.0.0.1", "localhost", "::1"].includes(host)) {
+    app.use(localhostHostValidation());
+  }
 
   app.use((_req, res, next) => {
     res.setHeader(
@@ -131,6 +145,32 @@ export function createHttpApp({ host = process.env.HOST || "127.0.0.1" } = {}) {
 
   app.get("/mcp", methodNotAllowed);
   app.delete("/mcp", methodNotAllowed);
+
+  app.use((error, _req, res, next) => {
+    if (error?.type === "entity.too.large") {
+      res.status(413).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32600,
+          message: "Request body exceeds the 1 MiB limit.",
+        },
+        id: null,
+      });
+      return;
+    }
+    if (error?.type === "entity.parse.failed") {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32700,
+          message: "Invalid JSON request body.",
+        },
+        id: null,
+      });
+      return;
+    }
+    next(error);
+  });
 
   return app;
 }

--- a/apps/chatgpt-academic-writing-toolkit/test/server.test.js
+++ b/apps/chatgpt-academic-writing-toolkit/test/server.test.js
@@ -2,7 +2,10 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-import { createHttpApp } from "../src/server.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+import { createHttpApp, MAX_REQUEST_BYTES } from "../src/server.js";
 
 async function readJson(url) {
   return JSON.parse(await readFile(url, "utf8"));
@@ -48,6 +51,58 @@ test("HTTP app exposes package-aligned health and guards non-POST MCP requests",
     } else {
       process.env.OPENAI_APPS_CHALLENGE = oldChallenge;
     }
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+});
+
+test("HTTP app accepts every schema-valid single-text request and bounds larger bodies", async () => {
+  const app = createHttpApp({ host: "127.0.0.1" });
+  const server = await new Promise((resolve) => {
+    const listener = app.listen(0, "127.0.0.1", () => resolve(listener));
+  });
+  const port = server.address().port;
+  const client = new Client({ name: "awt-http-limit-test", version: "1.0.0" });
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${port}/mcp`),
+  );
+
+  try {
+    await client.connect(transport);
+    const response = await client.callTool({
+      name: "check_british_english",
+      arguments: { text: "a".repeat(100_000) },
+    });
+    assert.equal(response.isError, undefined);
+
+    const oversized = await fetch(`http://127.0.0.1:${port}/mcp`, {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: {
+          name: "check_british_english",
+          arguments: { text: "a".repeat(MAX_REQUEST_BYTES) },
+        },
+      }),
+    });
+    assert.equal(oversized.status, 413);
+    assert.deepEqual(await oversized.json(), {
+      jsonrpc: "2.0",
+      error: {
+        code: -32600,
+        message: "Request body exceeds the 1 MiB limit.",
+      },
+      id: null,
+    });
+  } finally {
+    await client.close();
     await new Promise((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
     });

--- a/awt/__init__.py
+++ b/awt/__init__.py
@@ -1,3 +1,3 @@
 """Shared runtime for the Academic Writing Toolkit."""
 
-__version__ = "0.5.0rc3"
+__version__ = "0.5.0rc4"

--- a/docs/chatgpt-app-design.md
+++ b/docs/chatgpt-app-design.md
@@ -6,10 +6,13 @@ Build a `tool-only` ChatGPT App for the Academic Writing Toolkit while keeping t
 
 This gives the project two distribution tracks:
 
-- ChatGPT App: public MCP server submitted through OpenAI Platform Apps Manage.
+- ChatGPT App: public MCP server scanned and submitted through the OpenAI Plugins portal.
 - Codex plugin: local plugin package under `plugins/academic-writing-toolkit`, with official public distribution following OpenAI's app approval and publication flow.
 
-Both surfaces use package version `0.4.0` for the current release. The ChatGPT App server reads its version from `apps/chatgpt-academic-writing-toolkit/package.json`, and the test suite checks that it matches the Codex plugin manifest version.
+For the RC4 candidate, the Workbench uses PEP 440 version `0.5.0rc4`, while the
+plugin and ChatGPT App use the equivalent SemVer `0.5.0-rc.4`. Automated tests
+check that these release identities remain aligned. The ChatGPT App server reads
+its version from `apps/chatgpt-academic-writing-toolkit/package.json`.
 
 ## User Flows
 

--- a/docs/chatgpt-app-publishing.md
+++ b/docs/chatgpt-app-publishing.md
@@ -152,17 +152,16 @@ curl -i https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp
 curl -fsS https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/.well-known/openai-apps-challenge
 ```
 
-Pre-deployment hosted verification:
+Latest hosted verification:
 
 - Date: 2026-07-29
-- Space repo/runtime SHA: `5c0703a256460782fa4551ac2b4eadb919b92058`
-- `/health`: version `0.3.2`, `status: ok`
+- Space repo/runtime SHA: `876c6cf357de4dbdd2057066570b4f5a4366caa9`
+- `/health`: version `0.5.0-rc.4`, `status: ok`
 - `GET /mcp`: `405 Method not allowed`
-- MCP initialize: server version `0.3.2`, five tools
+- MCP initialize: server version `0.5.0-rc.4`
+- MCP scan smoke: five tools; all five declare the three required annotations and
+  `outputSchema`; five safe calls passed
 - `/.well-known/openai-apps-challenge`: returned the configured OpenAI challenge token
-
-This block records the old live state and must be replaced with the RC4 Space SHA and
-live checks after deployment.
 
 Latest OpenAI dashboard check:
 

--- a/docs/chatgpt-app-publishing.md
+++ b/docs/chatgpt-app-publishing.md
@@ -19,14 +19,15 @@ The app-specific check runs the Node test suite for the MCP server and tool wrap
 ## Review Artifacts
 
 - MCP server path: `apps/chatgpt-academic-writing-toolkit/src/server.js`
-- Submission import file: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
+- Submission checklist file: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
 - Privacy URL source: `docs/privacy.md`
 - Terms URL source: `docs/terms.md`
-- App package version: `0.4.0`, aligned with `plugins/academic-writing-toolkit/.codex-plugin/plugin.json`
+- App package version target: `0.5.0-rc.4`, aligned with `plugins/academic-writing-toolkit/.codex-plugin/plugin.json`
 
-## Current v0.4.0 Submission Endpoint
+## Current v0.5.0-rc.4 Submission Endpoint
 
-For the zero-cost v0.4.0 update of the already-published ChatGPT App, keep the existing Hugging Face Space MCP base URL:
+For the v0.5.0-rc.4 update of the existing ChatGPT App draft, keep the existing
+Hugging Face Space MCP base URL:
 
 ```text
 https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp
@@ -39,7 +40,7 @@ Dashboard fields:
 - MCP Server URL: `https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp`
 - Privacy Policy URL: `https://github.com/yha9806/academic-writing-toolkit/blob/main/docs/privacy.md`
 - Terms of Service URL: `https://github.com/yha9806/academic-writing-toolkit/blob/main/docs/terms.md`
-- Submission import file: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
+- Submission checklist file: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
 
 Smoke-test before submitting:
 
@@ -48,11 +49,16 @@ curl -fsS https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/healt
 curl -i https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp
 ```
 
-After the hosted Space is updated from the `v0.4.0` package, `/health` should return version `0.4.0` and `status: ok`. `GET /mcp` should return `405`; MCP traffic uses `POST /mcp`.
+After deployment, `/health` and MCP `serverInfo` must return version
+`0.5.0-rc.4`. `GET /mcp` should return `405`; MCP traffic uses `POST /mcp`.
 
-OpenAI currently requires an updated app draft to keep the same MCP base URL as the published version. Use the Render URL only for backup smoke testing or for a separate future app listing.
+The existing registered draft already uses the Hugging Face endpoint. Keep that
+verified endpoint for this update unless the live portal explicitly permits and verifies
+a replacement. The Render URL remains a backup smoke-test endpoint.
 
-For the previous v0.3.0 draft, OpenAI Platform accepted the Hugging Face Space URL, confirmed domain verification, scanned 5 tools, and applied 5 imported tool justifications. For v0.4.0, keep the same MCP base URL and re-import the same submission file after the hosted Space reports version `0.4.0`.
+The endpoint previously passed domain verification and exposed five tools. Re-scan the
+deployed RC4 endpoint and enter the reviewed checklist values again; prior scan results
+do not prove the new deployment.
 
 ## Deployment Requirement
 
@@ -116,28 +122,27 @@ After the hosting rewrite is deployed, submit:
 https://YOUR_DOMAIN/mcp
 ```
 
-as the MCP Server URL in OpenAI Platform Apps Manage.
+as the MCP Server URL in the OpenAI Plugins portal.
 
 See `deploy/cloud-run/README.md` for build, deploy, verification, and rewrite examples.
 
 ## Hugging Face Space Deployment
 
-The already-published ChatGPT App is bound to the Hugging Face Space domain:
+The existing registered ChatGPT App draft uses the Hugging Face Space domain:
 
 ```text
 https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space
 ```
 
-Use the Hugging Face Space path when updating the published app because OpenAI Platform rejects changing the MCP base URL inside the existing app version lineage.
+Use the Hugging Face Space path for this draft update because it is the existing
+domain-verified endpoint. Re-check the live portal before asserting any immutable
+published-version URL rule.
 
 The Space is a Docker Space on the free `cpu-basic` runtime. The Space root `Dockerfile` uses `PORT=7860`; keep that root Dockerfile in the Space even though the repository app Dockerfile uses `PORT=3000` for generic Docker hosts.
 
-Update the Space from the repository root with a bounded upload package that includes:
-
-- root Space `Dockerfile`
-- root Space `README.md`
-- `apps/chatgpt-academic-writing-toolkit/`
-- runtime scripts under `scripts/`
+Update the Space through a Hugging Face pull request containing only runtime files whose
+hashes differ from the current Space. Do not upload the GitHub repository root, use
+`--delete`, or replace the Space's root `Dockerfile` and `README.md`.
 
 After upload, wait until the Space runtime SHA matches the latest Space repo SHA, then verify:
 
@@ -147,13 +152,17 @@ curl -i https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp
 curl -fsS https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/.well-known/openai-apps-challenge
 ```
 
-Latest hosted verification:
+Pre-deployment hosted verification:
 
-- Date: 2026-07-08
+- Date: 2026-07-29
 - Space repo/runtime SHA: `5c0703a256460782fa4551ac2b4eadb919b92058`
-- `/health`: version `0.4.0`, `status: ok`
+- `/health`: version `0.3.2`, `status: ok`
 - `GET /mcp`: `405 Method not allowed`
+- MCP initialize: server version `0.3.2`, five tools
 - `/.well-known/openai-apps-challenge`: returned the configured OpenAI challenge token
+
+This block records the old live state and must be replaced with the RC4 Space SHA and
+live checks after deployment.
 
 Latest OpenAI dashboard check:
 
@@ -170,7 +179,9 @@ Latest OpenAI dashboard check:
 
 ## Render Deployment
 
-Render is a zero-cost backup hosted path for smoke testing or for a separate future app listing. It is not the MCP URL for updates to the already-published OpenAI app, because that app is currently bound to the Hugging Face Space base URL.
+Render is a zero-cost backup hosted path for smoke testing or for a separate future
+listing. It is not the selected endpoint for this draft; the current domain-verified
+draft uses the Hugging Face Space URL.
 
 Cloud Run remains useful only if the MCP server must later live behind an existing Firebase Hosting domain path.
 
@@ -206,7 +217,7 @@ Setup:
 6. Add a dedicated custom domain, such as `awt.example.com`, as the Render custom domain for this service.
 7. In the DNS provider for that domain, create the CNAME record Render requests.
 8. Verify `https://YOUR_AWT_DOMAIN/health` returns `status: ok`.
-9. Use `https://YOUR_AWT_DOMAIN/mcp` as the MCP Server URL in OpenAI Platform Apps Manage.
+9. Use `https://YOUR_AWT_DOMAIN/mcp` as the MCP Server URL in the OpenAI Plugins portal.
 
 Keep the main site on its existing app. Do not route the main site's `/mcp` path to Academic Writing Toolkit; that would mix two products on the same review surface.
 
@@ -227,12 +238,15 @@ curl -fsS https://YOUR_AWT_DOMAIN/.well-known/openai-apps-challenge
 Before pressing Submit for review:
 
 - Complete OpenAI organization verification for the publisher name.
-- Confirm the submitting account has `api.apps.write`; use `api.apps.read` to view drafts and review status.
+- Confirm the submitting account has **Apps Management Write** permission.
 - Use a public HTTPS MCP URL that OpenAI can reach during automated checks and manual review.
-- For updates to the already-published app, use the Hugging Face Space MCP URL because OpenAI Platform requires the MCP base URL to match the current published version.
+- For this existing registered draft, use the currently verified Hugging Face Space MCP
+  URL unless the live portal explicitly accepts and verifies a replacement.
 - Pre-warm the Hugging Face Space with `/health` immediately before saving or submitting the OpenAI dashboard draft.
 - Keep the Render `onrender.com` URL as a backup smoke-test deployment only. Move to a custom domain or Firebase Hosting plus Cloud Run only if a future app version or separate listing needs that base URL.
-- Import `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json` into the dashboard form and re-check every generated test case.
+- Copy the reviewed values from
+  `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json` into the portal and
+  re-check every test case. Do not assume a JSON-import control exists.
 - Run the positive and negative test prompts in ChatGPT Developer Mode on web and mobile; expected outputs should be concise and match the stated tool behavior.
 - Confirm every tool descriptor has explicit `readOnlyHint`, `openWorldHint`, `destructiveHint`, and `outputSchema`.
 - Audit realistic tool responses for unnecessary personal data, debug fields, request IDs, logs, or secrets before submission.
@@ -240,14 +254,15 @@ Before pressing Submit for review:
 
 ## Official Review Flow
 
-As of 2026-07-08, use OpenAI Platform Apps Manage after deployment:
+Use the current OpenAI Plugins portal after deployment:
 
-https://platform.openai.com/apps-manage
+https://platform.openai.com/plugins
 
-OpenAI's Apps SDK submission docs state that the dashboard app review flow is the current path to public distribution, and that publishing an approved app creates the Codex distribution plugin. Self-serve standalone Codex plugin publishing is documented as coming soon.
+ChatGPT and Codex share one Plugins Directory. Submission, approval, and developer
+publication are separate states.
 
 Relevant docs:
 
-- https://developers.openai.com/apps-sdk/deploy/submission
+- https://developers.openai.com/plugins/deploy/submission
+- https://developers.openai.com/plugins/build/plugins
 - https://developers.openai.com/apps-sdk/app-submission-guidelines
-- https://developers.openai.com/apps-sdk/build/mcp-server

--- a/docs/openai-codex-plugin-submission.md
+++ b/docs/openai-codex-plugin-submission.md
@@ -1,31 +1,37 @@
-# OpenAI Codex Plugin Submission Packet
+# OpenAI Plugin Submission Packet
 
-This file records the official-format submission details for the Academic Writing Toolkit Codex plugin.
+This file records the submission details for the Academic Writing Toolkit skills companion
+and its separately deployed ChatGPT App MCP surface.
 
 ## Official Status
 
-As of 2026-07-08, OpenAI's Codex plugin build documentation describes the plugin package and marketplace model. OpenAI's Apps submission documentation says the current public distribution path is to submit a ChatGPT App through the dashboard; publishing an approved app creates the Codex distribution plugin, while self-serve plugin publishing is still documented as coming soon.
+OpenAI now uses one Plugins Directory for ChatGPT and Codex. The portal supports packages
+with skills, MCP apps, or both. A package is not public until it has passed OpenAI review
+and the developer publishes the approved version.
 
 Official docs:
 
-- https://developers.openai.com/codex/plugins
-- https://developers.openai.com/codex/plugins/build
-- https://developers.openai.com/apps-sdk/deploy/submission
+- https://developers.openai.com/plugins/build/plugins
+- https://developers.openai.com/plugins/deploy/submission
+- https://platform.openai.com/plugins
 
-This package is prepared to match the official Codex plugin package format. It has not been submitted to an official OpenAI public Plugin Directory because the official self-serve submission surface is not yet available in the documented developer flow.
+The repository plugin remains skills-only. A local combined plugin requires a real
+`plugin_asdk_app...` technical ID from an MCP connection registered in ChatGPT
+Developer Mode; do not invent that ID. The Plugins portal's **With MCP** flow instead
+accepts the production MCP URL directly.
 
 ## Package Target
 
 - Plugin name: `academic-writing-toolkit`
 - Display name: `Academic Writing Toolkit`
 - Repository: `https://github.com/yha9806/academic-writing-toolkit`
-- Package version: `0.4.0`
-- Tagged release ref for external review: `v0.4.0`
+- Package version: `0.5.0-rc.4`
+- Tagged release ref for external review: `v0.5.0rc4`
 - Current default branch ref used for local marketplace tracking: `main`
 - Plugin path: `plugins/academic-writing-toolkit`
 - Manifest: `plugins/academic-writing-toolkit/.codex-plugin/plugin.json`
 - Marketplace metadata for repo/team testing: `.agents/plugins/marketplace.json`
-- ChatGPT App submission import: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
+- ChatGPT App submission checklist: `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json`
 - Current ChatGPT App MCP URL for dashboard review: `https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp`
 
 ## Install Command For Review
@@ -36,10 +42,10 @@ Use `main` for current default-branch testing:
 codex marketplace add yha9806/academic-writing-toolkit --ref main --sparse .agents/plugins --sparse plugins/academic-writing-toolkit
 ```
 
-Use the immutable release tag after `v0.4.0` has been created:
+Use the immutable release tag after `v0.5.0rc4` has been created:
 
 ```bash
-codex marketplace add yha9806/academic-writing-toolkit --ref v0.4.0 --sparse .agents/plugins --sparse plugins/academic-writing-toolkit
+codex marketplace add yha9806/academic-writing-toolkit --ref v0.5.0rc4 --sparse .agents/plugins --sparse plugins/academic-writing-toolkit
 ```
 
 The local CLI currently exposes `codex marketplace add`. Some newer OpenAI docs show `codex plugin marketplace add`; use the command supported by the installed Codex CLI version.
@@ -51,8 +57,9 @@ The manifest follows the OpenAI Codex plugin docs:
 - Required entry point: `.codex-plugin/plugin.json`
 - Package metadata: `name`, `version`, `description`, `author`, `homepage`, `repository`, `license`, `keywords`
 - Bundled components: `skills: "./skills/"`
-- Install-surface metadata: `interface.displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities`, `websiteURL`, `privacyPolicyURL`, `termsOfServiceURL`, `defaultPrompt`, `brandColor`, `composerIcon`, `logo`, `screenshots`
+- Install-surface metadata: `interface.displayName`, `shortDescription`, `longDescription`, `developerName`, `category`, `capabilities`, `websiteURL`, `supportURL`, `privacyPolicyURL`, `termsOfServiceURL`, `defaultPrompt`, `brandColor`, `composerIcon`, `logo`
 - Asset paths: all visual assets live under `./assets/`
+- No screenshots: the skills-only companion has no custom UI
 - No absent component references: no `apps`, `mcpServers`, or `hooks` fields are declared unless those files are actually bundled
 
 ## Included Skills
@@ -62,6 +69,7 @@ The manifest follows the OpenAI Codex plugin docs:
 - `verify`
 - `map`
 - `evidence-review`
+- `argument-governance`
 - `integrate`
 - `thesis-control`
 - `audit`
@@ -72,18 +80,24 @@ The manifest follows the OpenAI Codex plugin docs:
 - `logic-review`
 - `verify-refs`
 - `human-eval-handoff-repair`
+- `peer-review`
+- `self-review`
 - `progress`
 - `export`
 
 ## Review Notes
 
-- The standalone plugin package is a Codex plugin package with bundled local skills and helper scripts.
-- The repository also exposes a separate tool-only ChatGPT App MCP server under `apps/chatgpt-academic-writing-toolkit/`.
-- `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json` is generated for the OpenAI Platform Apps dashboard review flow.
-- For the zero-cost v0.4.0 review path, submit `https://harryhurry-academic-writing-toolkit-chatgpt-app.hf.space/mcp` as the MCP Server URL after the hosted `/health` endpoint reports `0.4.0`.
-- On 2026-07-08, the OpenAI dashboard draft was ready on content, MCP URL, tool annotations, and test cases, but `Submit for Review` was blocked until the publisher organization completes OpenAI Business verification.
-- The package uses bundled local skills and helper scripts only.
-- The standalone plugin manifest does not currently declare `.app.json` or `.mcp.json`; public Codex distribution should follow the documented Apps approval and publication path until self-serve plugin publishing is available.
+- The skills companion bundles 20 local skills and their helper scripts.
+- It does not install or launch the local Workbench wheel.
+- The ChatGPT App exposes five deterministic pasted-text tools. It does not gain local
+  file discovery or Workbench agent execution merely because versions align.
+- Use `apps/chatgpt-academic-writing-toolkit/chatgpt-app-submission.json` as the
+  reviewed source when entering exactly five positive and three negative tests and the
+  annotation justifications in OpenAI Platform.
+- Submit the MCP URL only after `/health` and MCP `serverInfo` both report
+  `0.5.0-rc.4`, all five tools scan correctly, and production dependency audit is clean.
+- The standalone plugin manifest does not declare `.app.json`. A local combined plugin
+  would need a Developer Mode connection ID; the portal **With MCP** flow uses the URL.
 
 ## Verification
 
@@ -100,9 +114,11 @@ Expected result:
 
 - plugin skills are in sync with `.claude/skills`
 - plugin manifest and marketplace metadata validate
+- plugin version is SemVer and aligns with the App package
 - helper scripts expose usable `--help`
-- PNG asset paths and headers validate
+- icon asset paths and headers validate
 - ChatGPT App tool descriptors and wrappers pass their Node test suite
+- production dependency audit reports zero vulnerabilities
 - regression tests pass
 
 ## Community Submission Note

--- a/docs/plugin-publishing-checklist.md
+++ b/docs/plugin-publishing-checklist.md
@@ -4,9 +4,15 @@ Use this checklist before submitting or sharing the Academic Writing Toolkit Cod
 
 ## Official Directory Status
 
-OpenAI's current Codex plugin build documentation describes the plugin package and marketplace model, while Apps SDK submission documentation says public distribution currently runs through the dashboard app review flow. Until a self-serve official plugin submission surface is available, treat this repository as an official-format, submission-ready plugin package rather than a completed official directory listing.
+OpenAI now operates one Plugins Directory shared by ChatGPT and Codex. A package may
+contain skills, an MCP app, or both. Submission, review, and publication are separate
+states: a locally valid package or deployed MCP server is not automatically listed.
 
-Reference: https://developers.openai.com/codex/plugins/build
+References:
+
+- https://developers.openai.com/plugins/build/plugins
+- https://developers.openai.com/plugins/deploy/submission
+- https://platform.openai.com/plugins
 
 ## Required Local Checks
 
@@ -15,10 +21,15 @@ Run these from the repository root:
 ```bash
 make plugin-sync
 make plugin-check
+make chatgpt-app-check
+npm audit --prefix apps/chatgpt-academic-writing-toolkit --omit=dev --audit-level=high
 make test
 ```
 
-`make plugin-sync` regenerates `plugins/academic-writing-toolkit/skills/` from the canonical `.claude/skills/` directory. `make plugin-check` validates the plugin manifest, marketplace entry, bundled helper scripts, asset paths, PNG headers, and sync state.
+`make plugin-sync` regenerates `plugins/academic-writing-toolkit/skills/` from the
+canonical `.claude/skills/` directory. `make plugin-check` validates the skills-only
+manifest, marketplace entry, bundled helper scripts, SemVer, directory text limits,
+HTTPS URLs, icon assets, and sync state.
 
 ## Official Manifest Review
 
@@ -29,8 +40,12 @@ Check `plugins/academic-writing-toolkit/.codex-plugin/plugin.json` for:
 - `repository`, `homepage`, and `websiteURL`: public repository URLs
 - `privacyPolicyURL`: `docs/privacy.md` on the public default branch
 - `termsOfServiceURL`: `docs/terms.md` on the public default branch
-- `composerIcon`, `logo`, and `screenshots`: PNG paths under `./assets/`
+- `supportURL`: public issue tracker
+- `shortDescription`: no more than 30 characters
+- `composerIcon` and `logo`: PNG paths under `./assets/`
 - `defaultPrompt`: no more than three short starter prompts
+- no `screenshots` for this no-UI, skills-only package
+- no `apps` or `mcpServers` in the skills-only ZIP
 
 OpenAI's published plugin manifest example uses these same field groups: package metadata, bundled component paths, and the `interface` install-surface metadata.
 
@@ -48,18 +63,25 @@ This repo marketplace is for local, repo, team, or personal distribution. It is 
 
 ## Asset Review
 
-Current local assets live in `plugins/academic-writing-toolkit/assets/`:
+Current manifest assets live in `plugins/academic-writing-toolkit/assets/`:
 
 - `icon.png`
 - `logo.png`
-- `screenshot-workflow.png`
-- `screenshot-progress.png`
 
-These are functional generated assets. Replace them with final branded assets before a polished public launch if desired, then rerun `make plugin-check`.
+Historical screenshots remain in the repository but are excluded from the skills-only
+manifest because this package has no custom UI.
 
 ## Submission Packet
 
-Before an official OpenAI public plugin submission surface is available, keep the review packet in `docs/openai-codex-plugin-submission.md` current. It records the repository URL, plugin path, release ref, install command, manifest mapping, and local verification evidence.
+Keep `docs/openai-codex-plugin-submission.md` current. Before submission:
+
+- deploy and live-test the MCP endpoint
+- scan the endpoint in OpenAI Platform and confirm all five tool annotations
+- keep exactly five positive and three negative App test cases
+- use the portal's **With MCP** flow and production URL for the public submission;
+  use a real Developer Mode connection ID only when building a local combined package
+- confirm publisher identity and policy declarations in the portal
+- upload the exact reviewed package, then submit it for review
 
 ## Release Notes
 
@@ -68,5 +90,7 @@ Before publishing a new version:
 - update the manifest `version`
 - run `make plugin-sync`
 - run `make plugin-check`
+- run `make chatgpt-app-check` and the production dependency audit
 - run `make test`
-- commit the generated plugin package and supporting docs together
+- commit the plugin/App package and supporting docs together
+- deploy and verify before changing any document from “target” to “live”

--- a/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
+++ b/plugins/academic-writing-toolkit/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
     "name":  "academic-writing-toolkit",
-    "version":  "0.4.0",
+    "version":  "0.5.0-rc.4",
     "description":  "Academic reading, thesis writing, thesis drift control, manuscript reframing, revision escalation, evidence-controlled review synthesis, release governance, citation auditing, British English checking, reference verification, human-evaluation handoff repair, and export skills for Codex.",
     "author":  {
                    "name":  "Academic Writing Toolkit Maintainers",
@@ -29,7 +29,7 @@
     "skills":  "./skills/",
     "interface":  {
                       "displayName":  "Academic Writing Toolkit",
-                      "shortDescription":  "Structured research, thesis drift control, manuscript reframing, revision escalation, evidence-review, release governance, citation, style, and export workflows.",
+                      "shortDescription":  "Evidence-led academic writing",
                       "longDescription":  "Academic Writing Toolkit packages local Codex skills for reading PDFs, recording source notes, mapping literature to chapters, building evidence-controlled gap reviews, controlling AI-assisted thesis edits with spine cards and drift audits, reframing report-like drafts into scientific manuscripts, stopping repeated failed revisions for diagnosis before more patches, integrating arguments, auditing citations and consistency, preparing release-governance packets, validating and repairing human-evaluation handoff packages, checking British English, reviewing paragraph logic, verifying BibTeX records, tracking progress, and exporting thesis materials.",
                       "developerName":  "Academic Writing Toolkit Maintainers",
                       "category":  "Productivity",
@@ -39,6 +39,7 @@
                                            "Review"
                                        ],
                       "websiteURL":  "https://github.com/yha9806/academic-writing-toolkit",
+                      "supportURL":  "https://github.com/yha9806/academic-writing-toolkit/issues",
                       "privacyPolicyURL":  "https://github.com/yha9806/academic-writing-toolkit/blob/main/docs/privacy.md",
                       "termsOfServiceURL":  "https://github.com/yha9806/academic-writing-toolkit/blob/main/docs/terms.md",
                       "defaultPrompt":  [
@@ -48,10 +49,6 @@
                                         ],
                       "brandColor":  "#2563EB",
                       "composerIcon":  "./assets/icon.png",
-                      "logo":  "./assets/logo.png",
-                      "screenshots":  [
-                                          "./assets/screenshot-workflow.png",
-                                          "./assets/screenshot-progress.png"
-                                      ]
+                      "logo":  "./assets/logo.png"
                   }
 }

--- a/plugins/academic-writing-toolkit/README.md
+++ b/plugins/academic-writing-toolkit/README.md
@@ -1,8 +1,16 @@
 # Academic Writing Toolkit Plugin
 
-This Codex plugin packages the academic-writing-toolkit skills for structured research and thesis writing workflows.
+This Codex plugin packages the Academic Writing Toolkit skills for structured research and
+thesis writing workflows.
 
-The plugin is Codex-complete: it does not require Gemini, gemini-agent, subagents, or external model review. External review tools may be used as optional advisory inputs, but local files and bundled checks remain the evidence boundary.
+This is the skills companion, not the local Workbench runtime. Installing it makes the 20
+bundled workflows available to a compatible agent host; it does not install or start the
+`awt` local web workbench. The Workbench is distributed separately as a wheel on the
+[GitHub Releases page](https://github.com/yha9806/academic-writing-toolkit/releases).
+
+The plugin does not require Gemini, gemini-agent, subagents, or external model review.
+External review tools may be used as optional advisory inputs, but local files and bundled
+checks remain the evidence boundary.
 
 An enhanced advisory mode can use API-key-backed external review when the user explicitly opts in. API keys should stay in environment variables, and any external output remains advisory rather than evidence.
 
@@ -44,11 +52,11 @@ Script-backed skills use helper scripts bundled inside the individual skill dire
 
 ## Publishing Assets
 
-The plugin manifest references local PNG assets under `assets/`:
+The skills-only plugin manifest references these local PNG assets under `assets/`:
 
 - `icon.png`
 - `logo.png`
-- `screenshot-workflow.png`
-- `screenshot-progress.png`
 
-Run `make plugin-check` before publishing to validate the manifest, marketplace entry, bundled helpers, and asset paths.
+Historical screenshots remain in the repository but are not part of the no-UI directory
+manifest. Run `make plugin-check` before publishing to validate the manifest, marketplace
+entry, bundled helpers, release metadata, and asset paths.

--- a/scripts/check-mvp-install.sh
+++ b/scripts/check-mvp-install.sh
@@ -104,7 +104,7 @@ from importlib.resources import files
 import awt
 from awt.mvp import WORKFLOWS
 
-assert awt.__version__ == "0.5.0rc3"
+assert awt.__version__ == "0.5.0rc4"
 assert len(WORKFLOWS) == 5
 assert files("awt").joinpath("mvp_index.html").is_file()
 assert files("awt").joinpath("demo-paper.md").is_file()
@@ -112,7 +112,7 @@ PY
     PYTHONDONTWRITEBYTECODE=1 "$temporary/venv/bin/python" -m unittest discover \
         -s "$REPO_ROOT/tests/runtime" -p 'test_*.py' >/dev/null
     "$temporary/venv/bin/awt" --help >/dev/null
-    "$temporary/venv/bin/awt" --version | grep -q '0.5.0rc3'
+    "$temporary/venv/bin/awt" --version | grep -q '0.5.0rc4'
     AWT_CODEX_BIN="$temporary/fake-codex" \
         AWT_SESSION_DIR="$temporary/sessions" \
         "$temporary/venv/bin/awt" --check | grep -q 'Local preflight: ready'

--- a/scripts/check-plugin.sh
+++ b/scripts/check-plugin.sh
@@ -41,8 +41,11 @@ PYTHON="$PYTHON_BIN" bash "$SCRIPT_DIR/sync-plugin.sh" --check >/dev/null
 
 "$PYTHON_BIN" - "$PLUGIN_JSON" "$MARKETPLACE_JSON" <<'PY'
 import json
+import re
 import sys
+import unicodedata
 from pathlib import Path
+from urllib.parse import urlparse
 
 plugin_path = Path(sys.argv[1])
 marketplace_path = Path(sys.argv[2])
@@ -52,6 +55,31 @@ marketplace = json.loads(marketplace_path.read_text(encoding="utf-8"))
 name = "academic-writing-toolkit"
 if plugin.get("name") != name:
     raise SystemExit("plugin name must be academic-writing-toolkit")
+if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]{0,63}", name):
+    raise SystemExit("plugin name must satisfy final directory format and length limits")
+version = plugin.get("version", "")
+if not re.fullmatch(
+    r"(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?",
+    version,
+):
+    raise SystemExit("plugin version must be valid SemVer")
+if len(version) > 64:
+    raise SystemExit("plugin version must contain at most 64 characters")
+description = plugin.get("description")
+if not isinstance(description, str) or not description or len(description) > 1024:
+    raise SystemExit("plugin description must contain 1-1024 characters")
+author = plugin.get("author")
+if not isinstance(author, dict):
+    raise SystemExit("plugin author must be an object")
+author_name = author.get("name")
+if (
+    not isinstance(author_name, str)
+    or not author_name
+    or "\n" in author_name
+    or len(author_name) > 120
+):
+    raise SystemExit("plugin author.name must contain 1-120 single-line characters")
 if plugin.get("skills") != "./skills/":
     raise SystemExit("plugin skills path must be ./skills/")
 if "hooks" in plugin or "mcpServers" in plugin or "apps" in plugin:
@@ -68,28 +96,165 @@ for field in [
     "category",
     "defaultPrompt",
     "websiteURL",
+    "supportURL",
     "privacyPolicyURL",
     "termsOfServiceURL",
     "composerIcon",
     "logo",
-    "screenshots",
 ]:
     if not interface.get(field):
         raise SystemExit(f"plugin interface.{field} is required")
-if len(interface.get("defaultPrompt", [])) > 3:
-    raise SystemExit("plugin interface.defaultPrompt must contain at most 3 entries")
+short_description = interface["shortDescription"]
+if (
+    not isinstance(short_description, str)
+    or not short_description
+    or "\n" in short_description
+    or len(short_description) > 30
+):
+    raise SystemExit(
+        "plugin interface.shortDescription must contain 1-30 single-line characters"
+    )
+
+display_name = interface["displayName"]
+if (
+    not isinstance(display_name, str)
+    or not display_name
+    or "\n" in display_name
+    or len(display_name) > 30
+):
+    raise SystemExit(
+        "plugin interface.displayName must contain 1-30 single-line characters"
+    )
+
+long_description = interface["longDescription"]
+if (
+    not isinstance(long_description, str)
+    or not long_description
+    or len(long_description) > 4000
+):
+    raise SystemExit("plugin interface.longDescription must contain 1-4000 characters")
+
+developer_name = interface["developerName"]
+if (
+    not isinstance(developer_name, str)
+    or not developer_name
+    or "\n" in developer_name
+    or len(developer_name) > 80
+):
+    raise SystemExit(
+        "plugin interface.developerName must contain 1-80 single-line characters"
+    )
+if developer_name != author_name:
+    raise SystemExit("plugin author.name and interface.developerName must match")
+
+allowed_categories = {
+    "Productivity",
+    "Creativity",
+    "Developer Tools",
+    "Business & Operations",
+    "Data & Analytics",
+    "Communication",
+    "Education & Research",
+    "Security",
+    "Finance",
+    "Healthcare",
+    "Travel",
+    "Entertainment",
+    "Other",
+}
+if interface["category"] not in allowed_categories:
+    raise SystemExit("plugin interface.category is not supported")
+
+capabilities = interface.get("capabilities")
+if not isinstance(capabilities, list) or len(capabilities) > 20:
+    raise SystemExit("plugin interface.capabilities must contain at most 20 entries")
+for capability in capabilities:
+    if (
+        not isinstance(capability, str)
+        or not capability
+        or "\n" in capability
+        or len(capability) > 120
+    ):
+        raise SystemExit(
+            "each plugin capability must contain 1-120 single-line characters"
+        )
+
+default_prompts = interface["defaultPrompt"]
+if not isinstance(default_prompts, list) or not 1 <= len(default_prompts) <= 3:
+    raise SystemExit("plugin interface.defaultPrompt must contain 1-3 entries")
+normalised_prompts = set()
+for prompt in default_prompts:
+    if (
+        not isinstance(prompt, str)
+        or not prompt
+        or "\n" in prompt
+        or len(prompt) > 128
+        or "@" in prompt
+    ):
+        raise SystemExit(
+            "each default prompt must be single-line, mention-free, and 1-128 characters"
+        )
+    normalised = " ".join(unicodedata.normalize("NFKC", prompt).split()).casefold()
+    if normalised in normalised_prompts:
+        raise SystemExit("plugin default prompts must be unique after normalisation")
+    normalised_prompts.add(normalised)
+
+for field in [
+    "homepage",
+    "repository",
+]:
+    value = plugin.get(field)
+    parsed = urlparse(value) if isinstance(value, str) else None
+    if (
+        not parsed
+        or parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+    ):
+        raise SystemExit(f"plugin {field} must be an HTTPS URL")
+
+author_url = author.get("url")
+author_url_parsed = urlparse(author_url) if isinstance(author_url, str) else None
+if (
+    not author_url_parsed
+    or author_url_parsed.scheme != "https"
+    or not author_url_parsed.netloc
+    or author_url_parsed.username
+    or author_url_parsed.password
+    or len(author_url) > 1024
+):
+    raise SystemExit("plugin author.url must be a credential-free HTTPS URL")
+
+for field in [
+    "websiteURL",
+    "supportURL",
+    "privacyPolicyURL",
+    "termsOfServiceURL",
+]:
+    value = interface[field]
+    parsed = urlparse(value) if isinstance(value, str) else None
+    if (
+        not parsed
+        or parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.username
+        or parsed.password
+        or len(value) > 1024
+    ):
+        raise SystemExit(f"plugin interface.{field} must be an HTTPS URL")
+
+brand_color = interface.get("brandColor")
+if brand_color is not None and not re.fullmatch(r"#[0-9A-Fa-f]{6}", brand_color):
+    raise SystemExit("plugin interface.brandColor must be a six-digit hex colour")
 
 for field in ["composerIcon", "logo"]:
     value = interface[field]
     if not isinstance(value, str) or not value.startswith("./assets/") or not value.endswith(".png"):
         raise SystemExit(f"plugin interface.{field} must point to a PNG under ./assets/")
 
-screenshots = interface["screenshots"]
-if not isinstance(screenshots, list) or not 1 <= len(screenshots) <= 3:
-    raise SystemExit("plugin interface.screenshots must contain 1-3 PNG paths")
-for screenshot in screenshots:
-    if not isinstance(screenshot, str) or not screenshot.startswith("./assets/") or not screenshot.endswith(".png"):
-        raise SystemExit("plugin screenshots must be PNG files under ./assets/")
+if "screenshots" in interface:
+    raise SystemExit("skills-only plugins must not declare screenshots")
 
 entries = [entry for entry in marketplace.get("plugins", []) if entry.get("name") == name]
 if len(entries) != 1:
@@ -115,7 +280,7 @@ from pathlib import Path
 plugin_root = Path(sys.argv[1])
 plugin = json.loads(Path(sys.argv[2]).read_text(encoding="utf-8"))
 interface = plugin["interface"]
-assets = [interface["composerIcon"], interface["logo"], *interface["screenshots"]]
+assets = [interface["composerIcon"], interface["logo"]]
 
 for asset in assets:
     relative_asset = asset[2:] if asset.startswith("./") else asset

--- a/tests/runtime/test_mvp_runtime.py
+++ b/tests/runtime/test_mvp_runtime.py
@@ -11,6 +11,7 @@ import unittest
 from pathlib import Path
 from unittest.mock import patch
 
+import awt
 from awt.mvp import (
     MAX_AGENT_INPUT_TOKENS,
     MvpApplication,
@@ -100,6 +101,26 @@ def replacement_runner(text: str, _workflow: str, _purpose: str) -> dict:
 
 
 class LeanRuntimeTests(unittest.TestCase):
+    def test_release_versions_align_across_workbench_plugin_and_app(self):
+        repository_root = Path(__file__).resolve().parents[2]
+        plugin = json.loads(
+            (
+                repository_root
+                / "plugins/academic-writing-toolkit/.codex-plugin/plugin.json"
+            ).read_text(encoding="utf-8")
+        )
+        app = json.loads(
+            (
+                repository_root
+                / "apps/chatgpt-academic-writing-toolkit/package.json"
+            ).read_text(encoding="utf-8")
+        )
+        self.assertEqual(plugin["version"], app["version"])
+        self.assertEqual(
+            awt.__version__,
+            app["version"].replace("-rc.", "rc"),
+        )
+
     def test_cli_version_check_and_loopback_boundary(self):
         with tempfile.TemporaryDirectory() as temporary:
             fake_codex = Path(temporary) / "codex"
@@ -132,7 +153,7 @@ esac
                 env=environment,
             )
             self.assertEqual(version.returncode, 0)
-            self.assertIn("0.5.0rc3", version.stdout)
+            self.assertIn("0.5.0rc4", version.stdout)
             check = subprocess.run(
                 [sys.executable, "-m", "awt.mvp", "--check"],
                 text=True,


### PR DESCRIPTION
## Summary
- align Workbench 0.5.0rc4 with plugin/App 0.5.0-rc.4
- update the 20-skill Codex companion for current directory rules
- refresh the five-tool ChatGPT App dependencies and enforce a 1 MiB request boundary
- add plugin/App CI and truthful surface-boundary documentation

## Verification
- make test: 121/121
- make mvp-test: 11/11
- make mvp-install-check: fresh wheel install passed
- make plugin-check: passed
- make chatgpt-app-check: 8/8
- npm audit --omit=dev --audit-level=high: 0 vulnerabilities
- git diff --check: passed

## Evidence boundary
Engineering checks validate packaging and runtime behavior. They do not prove writing-effect improvement. The ChatGPT App remains five deterministic pasted-text tools; the local Workbench remains the Agent-powered surface.