### PR TITLE
Fix argument governance skill frontmatter

### DIFF
--- a/.claude/skills/argument-governance/SKILL.md
+++ b/.claude/skills/argument-governance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: argument-governance
-description: Build and audit the manuscript argument system: intent, gap-contribution alignment, hierarchical claims, evidence balance, limitations, and reviewer attack surfaces. Use when a paper, thesis chapter, review article, or rebuttal needs explicit intent registers, contribution chains, claim hierarchy, argument maps, evidence-fit checks, or reviewer-risk matrices before drafting, revision, peer review, or self-review.
+description: "Build and audit the manuscript argument system: intent, gap-contribution alignment, hierarchical claims, evidence balance, limitations, and reviewer attack surfaces. Use when a paper, thesis chapter, review article, or rebuttal needs explicit intent registers, contribution chains, claim hierarchy, argument maps, evidence-fit checks, or reviewer-risk matrices before drafting, revision, peer review, or self-review."
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write
 ---
 

--- a/plugins/academic-writing-toolkit/skills/argument-governance/SKILL.md
+++ b/plugins/academic-writing-toolkit/skills/argument-governance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: argument-governance
-description: Build and audit the manuscript argument system: intent, gap-contribution alignment, hierarchical claims, evidence balance, limitations, and reviewer attack surfaces. Use when a paper, thesis chapter, review article, or rebuttal needs explicit intent registers, contribution chains, claim hierarchy, argument maps, evidence-fit checks, or reviewer-risk matrices before drafting, revision, peer review, or self-review.
+description: "Build and audit the manuscript argument system: intent, gap-contribution alignment, hierarchical claims, evidence balance, limitations, and reviewer attack surfaces. Use when a paper, thesis chapter, review article, or rebuttal needs explicit intent registers, contribution chains, claim hierarchy, argument maps, evidence-fit checks, or reviewer-risk matrices before drafting, revision, peer review, or self-review."
 allowed-tools: Read, Glob, Grep, Bash, Edit, Write
 ---
 


### PR DESCRIPTION
## What changed

- Quote the argument-governance skill description in both canonical and plugin mirrors.

## Why

OpenAI skill scanning rejected the previous plain scalar because the system-colon-intent phrase is invalid unquoted YAML.

## Validation

- 40/40 skill frontmatters parsed with PyYAML
- sync-plugin check
- plugin-check
- git diff check