### PR TITLE
Refuse a non-skill catalogue entry, and ship a supported launch command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,17 @@ provider key at run time.
 ```bash
 node scaffold/awt.mjs init ~/thesis          # clean workspace + skill links
 node scaffold/awt.mjs install-profile        # awt-headless + awt-web into ~/.dsh
-cd ~/thesis
 export DEEPSEEK_API_KEY=...                  # or ANTHROPIC_API_KEY
-npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-headless "task"
+node scaffold/awt.mjs run ~/thesis "task"    # one headless task
 
-# or the same enforcement behind dsh's web UI:
-npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-web --host 127.0.0.1 --port 3180
+# or the same enforcement behind dsh's web UI, then open the printed URL:
+node scaffold/awt.mjs web ~/thesis           # 127.0.0.1:3180 by default
 ```
+
+`run` and `web` launch the pinned harness that `install-profile` placed in
+`$DSH_HOME`, refuse a target that is not a workspace, and refuse a launcher
+whose version is not the one `COMPAT.json` attests. Your provider key stays
+in your environment; no AWT command reads or stores one.
 
 `node scaffold/awt.mjs verify ~/thesis` runs the five-stage verification
 ladder (build, notes-lint smoke, composition proof, scripted-denial evidence

--- a/docs/e2-dogfood-runbook.md
+++ b/docs/e2-dogfood-runbook.md
@@ -29,9 +29,8 @@ only; profile files carry `apiKeyEnv` references, never values.
 Run every step from inside the workspace so the guards see it:
 
 ```bash
-cd ~/thesis
 export DEEPSEEK_API_KEY=...
-npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-headless "<task>"
+node scaffold/awt.mjs run ~/thesis "<task>"
 ```
 
 1. **read** — put the chapter's key source PDF under `literature/`; task:

--- a/guards/tests/scaffold.test.ts
+++ b/guards/tests/scaffold.test.ts
@@ -164,3 +164,64 @@ test('init links exactly the real skills of a clean catalogue', () => {
   assert.equal(res.status, 0, res.stderr)
   assert.deepEqual(readdirSync(join(ws, '.agents', 'skills')).sort(), ['note', 'read'])
 })
+
+// --- awt web / awt run: the supported launch path ----------------------------------
+// `install-profile` already places the pinned launcher inside
+// $DSH_HOME/profiles/node_modules. These gates pin the refusals that run
+// BEFORE anything boots, so they need neither a harness nor a credential.
+
+/** A $DSH_HOME with an installed profile and a launcher of the given version. */
+function dshHome(opts: { profile?: string; harnessVersion?: string | null }): string {
+  const home = scratch()
+  if (opts.profile) mkdirSync(join(home, 'profiles', opts.profile), { recursive: true })
+  if (opts.harnessVersion !== null) {
+    const pkg = join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh')
+    mkdirSync(join(pkg, 'lib'), { recursive: true })
+    writeFileSync(join(pkg, 'lib', 'bin.js'), '')
+    writeFileSync(join(pkg, 'package.json'), JSON.stringify({ version: opts.harnessVersion }))
+  }
+  return home
+}
+
+function awtIn(home: string, ...args: string[]) {
+  return spawnSync(process.execPath, [AWT, ...args], {
+    encoding: 'utf8', timeout: 60_000, env: { ...process.env, DSH_HOME: home },
+  })
+}
+
+test('web refuses when the profile was never installed into DSH_HOME', () => {
+  const ws = join(scratch(), 'ws')
+  awt('init', ws)
+  const res = awtIn(dshHome({ harnessVersion: '0.1.0-rc.6' }), 'web', ws)
+  assert.notEqual(res.status, 0)
+  assert.match(res.stderr, /AWT_LAUNCH_PROFILE_MISSING/)
+  assert.match(res.stderr, /install-profile/)
+})
+
+test('web refuses a directory that is not an AWT workspace', () => {
+  const home = dshHome({ profile: 'awt-web', harnessVersion: '0.1.0-rc.6' })
+  const res = awtIn(home, 'web', scratch())
+  assert.notEqual(res.status, 0)
+  assert.match(res.stderr, /AWT_LAUNCH_NOT_WORKSPACE/)
+})
+
+test('launch refuses a harness that is not the COMPAT-pinned version', () => {
+  // Silently launching a different harness would void every attested gate.
+  const home = dshHome({ profile: 'awt-headless', harnessVersion: '0.1.2-rc.1' })
+  const ws = join(scratch(), 'ws')
+  awt('init', ws)
+  const res = awtIn(home, 'run', ws, 'anything')
+  assert.notEqual(res.status, 0)
+  assert.match(res.stderr, /AWT_LAUNCH_HARNESS_UNPINNED/)
+  assert.match(res.stderr, /0\.1\.2-rc\.1/)
+  const pinned = JSON.parse(readFileSync(resolve(import.meta.dirname, '..', '..', 'COMPAT.json'), 'utf8')).harness
+  assert.match(res.stderr, new RegExp(pinned.split('@').pop().replace(/\./g, '\\.')))
+})
+
+test('run refuses without a task, and web without a workspace', () => {
+  const home = dshHome({ profile: 'awt-headless', harnessVersion: '0.1.0-rc.6' })
+  const ws = join(scratch(), 'ws')
+  awt('init', ws)
+  assert.match(awtIn(home, 'run', ws).stderr, /AWT_LAUNCH_USAGE/)
+  assert.match(awtIn(home, 'web').stderr, /AWT_LAUNCH_USAGE/)
+})

--- a/guards/tests/scaffold.test.ts
+++ b/guards/tests/scaffold.test.ts
@@ -7,11 +7,12 @@
 import { test, after } from 'node:test'
 import assert from 'node:assert/strict'
 import { spawnSync } from 'node:child_process'
-import { lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import { cpSync, lstatSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, readlinkSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
 const AWT = resolve(import.meta.dirname, '..', '..', 'scaffold', 'awt.mjs')
+const TEMPLATE = resolve(import.meta.dirname, '..', '..', 'literature', 'reading_notes', '_template_NOTES.md')
 
 const dirs: string[] = []
 after(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }) })
@@ -122,4 +123,44 @@ test('install-profile lands both canonical profiles in a DSH_HOME and refuses to
   const again = awt('install-profile', home)
   assert.notEqual(again.status, 0)
   assert.match(again.stderr, /AWT_PROFILE_EXISTS/)
+})
+
+/**
+ * A throwaway product root holding only what `init` reads: the scaffold entry
+ * point, the notes template, and a catalogue built to order. `true` makes a
+ * real skill (a directory with a SKILL.md); `false` makes a bare directory.
+ */
+function productRoot(catalogue: Record<string, boolean>): string {
+  const root = scratch()
+  mkdirSync(join(root, 'scaffold'), { recursive: true })
+  cpSync(AWT, join(root, 'scaffold', 'awt.mjs'))
+  mkdirSync(join(root, 'literature', 'reading_notes'), { recursive: true })
+  cpSync(TEMPLATE, join(root, 'literature', 'reading_notes', '_template_NOTES.md'))
+  for (const [name, isSkill] of Object.entries(catalogue)) {
+    const dir = join(root, '.claude', 'skills', name, 'scripts')
+    mkdirSync(dir, { recursive: true })
+    if (isSkill) writeFileSync(join(root, '.claude', 'skills', name, 'SKILL.md'), `---\nname: ${name}\n---\n`)
+  }
+  return join(root, 'scaffold', 'awt.mjs')
+}
+
+test('init refuses a catalogue directory with no SKILL.md — build residue never becomes an extra skill', () => {
+  // A retired skill whose sources are gone but whose __pycache__ survives is
+  // invisible to `git status` and to every tracked-tree test, but readdir
+  // still sees the directory. Linking it hands the model a catalogue entry
+  // that resolves to nothing.
+  const entry = productRoot({ note: true, read: true, 'retired-skill': false })
+  const ws = join(scratch(), 'ws')
+  const res = spawnSync(process.execPath, [entry, 'init', ws], { encoding: 'utf8', timeout: 60_000 })
+  assert.notEqual(res.status, 0, 'a directory with no SKILL.md must not be linked as a skill')
+  assert.match(res.stderr, /AWT_INIT_NOT_A_SKILL/)
+  assert.match(res.stderr, /retired-skill/)
+})
+
+test('init links exactly the real skills of a clean catalogue', () => {
+  const entry = productRoot({ note: true, read: true })
+  const ws = join(scratch(), 'ws')
+  const res = spawnSync(process.execPath, [entry, 'init', ws], { encoding: 'utf8', timeout: 60_000 })
+  assert.equal(res.status, 0, res.stderr)
+  assert.deepEqual(readdirSync(join(ws, '.agents', 'skills')).sort(), ['note', 'read'])
 })

--- a/profiles/README.md
+++ b/profiles/README.md
@@ -23,17 +23,22 @@ node scaffold/awt.mjs install-profile
 Verify the composition without booting or credentials:
 
 ```bash
-DSH_HOME=~/.dsh npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-headless --dump-config | grep awt-guards
+node ~/.dsh/profiles/node_modules/@deepseek-ai/dsh/lib/bin.js \\
+  --profile awt-headless --dump-config | grep awt-guards
 ```
 
 Run inside a thesis workspace created by `awt init` (profile boot is a
 truth test — the guards refuse to mount against a non-workspace directory):
 
 ```bash
-cd <your-thesis-workspace>
 export DEEPSEEK_API_KEY=...   # or ANTHROPIC_API_KEY for the anthropic route
-npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-headless "task"
+node scaffold/awt.mjs run <your-thesis-workspace> "task"
 ```
+
+`awt run` resolves the pinned launcher from `$DSH_HOME/profiles/node_modules`
+— the dependency tree `install-profile` already wrote — so no package is
+resolved at launch time and an off-pin harness is a typed refusal
+(`AWT_LAUNCH_HARNESS_UNPINNED`).
 
 Remove by deleting `$DSH_HOME/profiles/awt-headless`; upgrade by
 re-running `install-profile` after removing (never merges in place).
@@ -47,9 +52,8 @@ bundle name, which is the point: the product is the composition, not the
 shell. `awt install-profile` installs both profiles together.
 
 ```bash
-cd <your-thesis-workspace-or-anywhere>
 export DEEPSEEK_API_KEY=...
-npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-web --host 127.0.0.1 --port 3180
+node scaffold/awt.mjs web <your-thesis-workspace> [port]
 ```
 
 Then open http://127.0.0.1:3180, add your workspace via the native folder

--- a/scaffold/awt.mjs
+++ b/scaffold/awt.mjs
@@ -36,6 +36,7 @@ const GUARDS_DIR = join(PRODUCT_ROOT, 'guards')
 const E2E_DIR = join(PRODUCT_ROOT, 'e2e')
 const PROFILE_SRC = join(PRODUCT_ROOT, 'profiles', 'awt-headless')
 const DSH_BIN = join(E2E_DIR, 'node_modules', '@deepseek-ai', 'dsh', 'lib', 'bin.js')
+const COMPAT = join(PRODUCT_ROOT, 'COMPAT.json')
 const RUN_TIMEOUT_MS = 300_000
 
 // --- typed failure -----------------------------------------------------------------
@@ -180,6 +181,73 @@ function installProfile(targetHome) {
   console.log(`web UI: run from your workspace — DSH_HOME=${home} npx --yes @deepseek-ai/dsh@0.1.0-rc.6 --profile awt-web --host 127.0.0.1 --port 3180`)
 }
 
+// --- launch ------------------------------------------------------------------------
+
+/** The one pin, read from COMPAT.json so a launcher and a claim cannot drift. */
+function pinnedHarnessVersion() {
+  return JSON.parse(readFileSync(COMPAT, 'utf8')).harness.split('@').pop()
+}
+
+/** The markers `init` creates; the same truth test `verify` applies. */
+function assertWorkspace(ws, code) {
+  for (const marker of ['chapters', join('literature', 'reading_notes'), join('.agents', 'skills')]) {
+    if (!existsSync(join(ws, marker))) {
+      throw new AwtError(code, `${ws} is not an AWT workspace (missing ${marker})`, 'run `awt init <dir>` first')
+    }
+  }
+}
+
+/**
+ * Run a profile against a workspace using the launcher `install-profile`
+ * already placed in $DSH_HOME — not a `npx` resolution and not a checkout's
+ * dev dependencies. Every refusal here happens before anything boots, so
+ * none of them needs a credential. The provider key stays in the caller's
+ * environment; this command never reads, stores or forwards one.
+ */
+function launch(profile, ws, extra) {
+  const home = resolve(process.env.DSH_HOME ?? join(process.env.HOME ?? '', '.dsh'))
+  if (!existsSync(join(home, 'profiles', profile))) {
+    throw new AwtError(
+      'AWT_LAUNCH_PROFILE_MISSING',
+      `${profile} is not installed in ${home}`,
+      `node ${relativeToCwd(join(PRODUCT_ROOT, 'scaffold', 'awt.mjs'))} install-profile`,
+    )
+  }
+  const pkgRoot = join(home, 'profiles', 'node_modules', '@deepseek-ai', 'dsh')
+  const bin = join(pkgRoot, 'lib', 'bin.js')
+  if (!existsSync(bin)) {
+    throw new AwtError(
+      'AWT_LAUNCH_HARNESS_MISSING',
+      `no dsh launcher under ${pkgRoot}`,
+      `reinstall the profiles so their dependency tree is present`,
+    )
+  }
+  // A different harness would void every gate COMPAT.json attests, so an
+  // unpinned launcher is a refusal, never a warning.
+  const want = pinnedHarnessVersion()
+  const got = JSON.parse(readFileSync(join(pkgRoot, 'package.json'), 'utf8')).version
+  if (got !== want) {
+    throw new AwtError(
+      'AWT_LAUNCH_HARNESS_UNPINNED',
+      `${pkgRoot} is @deepseek-ai/dsh@${got}; COMPAT.json attests ${want}`,
+      `reinstall the pinned harness, or re-attest COMPAT.json against ${got} first`,
+    )
+  }
+  assertWorkspace(ws, 'AWT_LAUNCH_NOT_WORKSPACE')
+  const res = spawnSync(process.execPath, [bin, '--profile', profile, ...extra], { cwd: ws, stdio: 'inherit' })
+  process.exit(res.status ?? 1)
+}
+
+function web(target, port) {
+  if (target === undefined) throw new AwtError('AWT_LAUNCH_USAGE', 'usage: awt web <workspace> [port]')
+  launch('awt-web', resolve(target), ['--host', '127.0.0.1', '--port', port ?? '3180'])
+}
+
+function runTask(target, task) {
+  if (target === undefined || task === undefined) throw new AwtError('AWT_LAUNCH_USAGE', 'usage: awt run <workspace> "<task>"')
+  launch('awt-headless', resolve(target), [task])
+}
+
 // --- verify ------------------------------------------------------------------------
 
 /** Run one ladder stage; on child failure raise typed with the output tail. */
@@ -288,12 +356,14 @@ async function verify(target) {
 
 // --- entry -------------------------------------------------------------------------
 
-const [command, target] = process.argv.slice(2)
+const [command, target, third] = process.argv.slice(2)
 try {
   if (command === 'init') init(target)
   else if (command === 'verify') await verify(target)
   else if (command === 'install-profile') installProfile(target)
-  else fail(new AwtError('AWT_USAGE', 'usage: awt <init|verify> <dir> | awt install-profile [dsh-home]'))
+  else if (command === 'web') web(target, third)
+  else if (command === 'run') runTask(target, third)
+  else fail(new AwtError('AWT_USAGE', 'usage: awt <init|verify> <dir> | awt install-profile [dsh-home] | awt web <dir> [port] | awt run <dir> "<task>"'))
 } catch (error) {
   fail(error instanceof AwtError ? error : new AwtError('AWT_UNEXPECTED', error?.stack ?? String(error)))
 }

--- a/scaffold/awt.mjs
+++ b/scaffold/awt.mjs
@@ -117,6 +117,18 @@ function init(target) {
     .map((entry) => entry.name)
     .sort()
   if (skills.length === 0) throw new AwtError('AWT_INIT_SKILLS_MISSING', `no skills found under ${SKILLS_SRC}`)
+  // A skill is a directory with a SKILL.md. A retired skill whose sources are
+  // gone but whose __pycache__ survives leaves a directory that `git status`
+  // cannot see (the residue is ignored) and readdir can, so it would be linked
+  // as a catalogue entry resolving to nothing.
+  const strays = skills.filter((name) => !existsSync(join(SKILLS_SRC, name, 'SKILL.md')))
+  if (strays.length > 0) {
+    throw new AwtError(
+      'AWT_INIT_NOT_A_SKILL',
+      `${SKILLS_SRC} holds ${strays.length} ${strays.length === 1 ? 'directory' : 'directories'} with no SKILL.md: ${strays.join(', ')}`,
+      `remove ${strays.length === 1 ? 'it' : 'them'} from the toolkit checkout, then re-run init`,
+    )
+  }
   for (const name of skills) {
     symlinkSync(join(SKILLS_SRC, name), join(ws, '.agents', 'skills', name))
   }


### PR DESCRIPTION
Two defects that only a real installation exposes, both found while walking the
whole path on a clean machine: pull main, install the profiles, create a
workspace, launch the app, complete a model round trip.

## 1. A catalogue directory with no `SKILL.md` became a tenth skill

A retired skill left behind `scripts/__pycache__` and nothing else. The residue
is gitignored, so `git status`, the tracked-tree catalogue tests and T50 all see
nine skills — while `awt init` reads the disk and linked ten. Every new
workspace got a catalogue entry pointing at a directory with no `SKILL.md`.

This is the "no output reads as no problem" failure applied to a directory
listing: nine tests green, wrong artifact. `init` now refuses with
`AWT_INIT_NOT_A_SKILL`, naming the offenders.

The test builds a throwaway product root (the scaffold entry point, the notes
template, and a catalogue made to order) rather than mutating this repository's
own `.claude/skills`. Its clean-catalogue twin proves the harness works, so a
red result is the assertion and not the fixture.

## 2. There was no supported way to start the app

`install-profile` has always written a dependency tree containing the pinned
`@deepseek-ai/dsh@0.1.0-rc.6` launcher into `$DSH_HOME/profiles/node_modules`,
and no document ever said so. Six places instead told the reader to
`npx --yes @deepseek-ai/dsh@0.1.0-rc.6 …`, which resolves the package at every
launch; on a cold cache that produced no output for over three minutes here.
The only command that worked pointed into `e2e/node_modules` — a dev artifact,
not a product surface.

`awt web <workspace> [port]` and `awt run <workspace> "<task>"` exec the
launcher already present in `$DSH_HOME`. Three refusals run before anything
boots, so none of them needs a credential:

| Refusal | Condition |
| --- | --- |
| `AWT_LAUNCH_PROFILE_MISSING` | the profile was never installed into `$DSH_HOME` |
| `AWT_LAUNCH_NOT_WORKSPACE` | the target fails the same truth test `verify` applies |
| `AWT_LAUNCH_HARNESS_UNPINNED` | the launcher's version is not the one `COMPAT.json` attests |

The third one matters most: silently running an off-pin harness would void
every gate that file claims. The pin is read from `COMPAT.json` at run time, so
a launcher and a claim cannot drift apart.

The provider key stays in the caller's environment. These commands never read,
store or forward one, and the six documents now show the working command.

## Evidence

Deterministic gates, this branch:

- `guards`: 106/106 (was 100; +2 catalogue, +4 launch)
- `make test`: 132/132

Against the real `~/.dsh`, on a workspace created by this branch's `init`:

- `awt verify` 5/5
- `awt run` completes a DeepSeek round trip; the agent identifies as AWT and
  binds to the workspace path
- `awt web` serves the branded UI on `127.0.0.1:3180`
- the workspace links exactly nine skills

This is E0 plus a manual installation walk-through. It is not E2 — no chapter
cycle was run, and nothing here claims one.

## Not in scope

`awt verify` still prints "5 scenarios" for an e2e table that has six on main.
That string is already corrected in #40; leaving it alone here avoids a
conflict.
