### PR TITLE
Declare the export backend as the prerequisite it became

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -124,6 +124,7 @@ approving it is not implementing it.
 ## Running the gates
 
 ```bash
+make setup                       # git config, generated configs, export backend, doctor
 npm ci --prefix guards && npm run build --prefix guards
 npm test --prefix guards         # kernel, testkit against the pinned harness, scaffold
 make test                        # the regression suite
@@ -135,6 +136,13 @@ node e1/run-e1.mjs               # offline instrument check
 ```
 
 All of these are keyless. Anything that needs a provider key is not a gate.
+
+`make setup` is not optional before `make test`: several tests run `doctor`,
+doctor asks the export converter whether it can convert, and the converter
+needs a Python backend this repository does not vendor. Without it those tests
+fail as something unrelated, so `scripts/test.sh` checks for a backend first
+and says so. CI installs the backend for itself, which is why a green CI run
+does not prove a fresh clone can run the suite.
 
 For an installation or first-run change, add the clean-machine walk:
 

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,10 @@ help:  ## Show this help (default)
 	@printf "When CLAUDE.md changes:  \033[36mmake sync\033[0m\n"
 	@printf "Health check anytime:    \033[36mmake doctor\033[0m\n"
 
-setup:  ## One-time setup after clone (sets git config, syncs configs, runs doctor)
+setup:  ## One-time setup after clone (git config, configs, export backend, doctor)
 	@git config core.fileMode false
 	@bash scripts/sync-config.sh
+	@bash scripts/setup-export-backend.sh
 	@bash scripts/doctor.sh
 
 init:  ## Open CLAUDE.md in $EDITOR for first-time customisation, then sync

--- a/scripts/setup-export-backend.sh
+++ b/scripts/setup-export-backend.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# scripts/setup-export-backend.sh — give /export a conversion backend.
+#
+# The converter needs pypandoc (the binding, not the `pandoc` binary) OR
+# python-docx AND markdown. A bare `pip install` is refused as
+# externally-managed by any PEP 668 interpreter, which is the default on
+# Homebrew Python and on current Debian and Ubuntu, so this creates a project
+# virtual environment — the location doctor, `awt verify` and the export tool
+# all look in. Idempotent: an interpreter that can already convert is left alone.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib.sh"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CONVERTER="$ROOT/.claude/skills/export/scripts/convert_to_docx.py"
+REQUIREMENTS="$ROOT/.claude/skills/export/scripts/requirements.txt"
+
+for candidate in "${AWT_PYTHON:-}" "$ROOT/.venv/bin/python" "$ROOT/.venv/Scripts/python.exe" python3; do
+    [ -n "$candidate" ] || continue
+    if command -v "$candidate" >/dev/null 2>&1 || [ -x "$candidate" ]; then
+        if "$candidate" "$CONVERTER" --check >/dev/null 2>&1; then
+            ok "export backend already available ($candidate)"
+            exit 0
+        fi
+    fi
+done
+
+command -v python3 >/dev/null 2>&1 || die "python3 not found; install it, then re-run make setup"
+printf "  creating %s and installing the export backend...\n" "$ROOT/.venv"
+python3 -m venv "$ROOT/.venv"
+"$ROOT/.venv/bin/pip" install --quiet --upgrade pip
+"$ROOT/.venv/bin/pip" install --quiet -r "$REQUIREMENTS"
+"$ROOT/.venv/bin/python" "$CONVERTER" --check >/dev/null \
+    || die "installed the requirements but the converter still reports no backend"
+ok "export backend installed into .venv"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -21,6 +21,14 @@ if [ -z "${AWT_PYTHON:-}" ]; then
         [ -x "$_candidate" ] && { export AWT_PYTHON="$_candidate"; break; }
     done
 fi
+# Doctor asks the export converter whether it can convert, and several tests
+# run doctor. Without a backend anywhere those tests fail as "T2 symlink
+# corruption + repair", which points at nothing. Say it here instead.
+if ! "${AWT_PYTHON:-python3}" "$REPO_ROOT/.claude/skills/export/scripts/convert_to_docx.py" --check >/dev/null 2>&1; then
+    printf "\033[31merror:\033[0m the export converter has no conversion backend, so the tests that run doctor cannot pass.\n" >&2
+    printf "       fix: make setup   (or: python3 -m venv .venv && .venv/bin/pip install -r .claude/skills/export/scripts/requirements.txt)\n" >&2
+    exit 2
+fi
 source "$SCRIPT_DIR/lib.sh"
 
 cd "$REPO_ROOT"


### PR DESCRIPTION
Follow-up to #47, found by running `make test` on a plain checkout right after
merging it.

#47 made `doctor` ask the export converter whether it can convert, and several
tests run `doctor`. On a checkout with no conversion backend the suite
therefore fails — **correctly**, which is the point of #47 — but it fails as:

```
1 test(s) failed:
  - T2  symlink corruption + repair
```

That names a symlink test and points at nothing a reader can act on. CI's green
said nothing about it, because CI installs the backend for itself.

## Three changes, all about saying it where it happens

- **`scripts/test.sh`** asks the converter before running anything, and exits
  with the real cause and a command that fixes it.
- **`make setup`** installs the backend into the project `.venv` that `doctor`,
  `awt verify` and the export tool all look in. Idempotent: an interpreter that
  can already convert is left alone.
- **`CONTRIBUTING.md`** states that `make setup` is not optional before
  `make test`, and why a green CI run does not prove a fresh clone can run the
  suite.

## Verified from a fresh clone, in order

| step | result |
| --- | --- |
| `bash scripts/test.sh` before setup | exit **2**, "the export converter has no conversion backend…" with the fix |
| `bash scripts/setup-export-backend.sh` | exit 0, "export backend installed into .venv" |
| `bash scripts/test.sh` after setup | exit 0, 132/132 |

Re-running setup on a checkout that already has a backend reports it and
changes nothing.

## Gates

Each status read on its own rather than through a pipe, because reading `$?`
after `cmd | tail` has produced three false greens in this work already:

```
guards 0 · make test 0 · e2e 0 · credential 0 · skill-scope 0 · e1 offline 0
```
