### PR TITLE
Gate A item 3: skills describe the surface they are running on

### DIFF
--- a/.claude/skills/edit-contract/SKILL.md
+++ b/.claude/skills/edit-contract/SKILL.md
@@ -58,8 +58,13 @@ produce a fourth patch under the old contract.
 
 1. One contract file per edit goal; append-only Attempts.
 2. Never edit outside Scope; never touch quoted spans.
-3. In P0 this discipline is advisory prose; the P1 guard enforces Scope and
-   the attempt count from the session log. Do not describe it as enforced.
+3. In the dsh app this is **enforced**: a write outside Scope is denied with
+   `CONTRACT_SCOPE`, and after three typed denials under one contract the next
+   in-scope chapter write asks the author (`ESCALATION_REQUIRED`), resolved
+   through the harness's own approval events. As a plain Agent Skill it is
+   advisory prose you follow. Say which surface you are on rather than
+   asserting either; the scope comes from the active contract on disk at the
+   moment of the decision.
 4. No emoji. British English.
 
 ## Project-level intent card (optional, Advisory)

--- a/.claude/skills/export/SKILL.md
+++ b/.claude/skills/export/SKILL.md
@@ -2,7 +2,7 @@
 name: export
 description: Convert thesis chapters and reading notes from Markdown to Word (.docx) and package for submission. Use when preparing materials for supervisors or examiners.
 disable-model-invocation: true
-allowed-tools: Bash(python *), Read, Glob, Write
+allowed-tools: Bash(python3 *), Read, Glob, Write
 ---
 
 # /export — Document Export Skill

--- a/.claude/skills/note/SKILL.md
+++ b/.claude/skills/note/SKILL.md
@@ -26,7 +26,7 @@ If the user says "take notes" without specifying what to record, default to reco
 
 ## Notes File Template
 
-This is the data contract shared across all skills (`/read`, `/note`, `/integrate`, `/map`, `/progress`). When creating a new notes file, use this exact structure:
+This is the data contract shared across all skills (`/read`, `/note`, `/integrate`, `/map`). When creating a new notes file, use this exact structure:
 
 ```markdown
 # Reading Notes: {Author} -- {Title} ({Year})

--- a/.claude/skills/read/SKILL.md
+++ b/.claude/skills/read/SKILL.md
@@ -14,20 +14,29 @@ allowed-tools: Read, Glob, Grep
 
 This skill activates on: `read`, `next page`, `continue`, `skip to p.N`, `read p.N`, `/read`.
 
-## PDF Limits (advisory in this release)
+## PDF limits
 
-- **Maximum 15 pages per invocation.**
-- **Maximum 90 pages per conversation** — a context-health budget. This is
-  currently an advisory rule the model follows imperfectly, not an enforced
-  counter; do not present it as tracked. (The dsh guard that enforces both
-  budgets deterministically ships in P1 of the dsh app.)
-- When a request clearly approaches the budget, say so and suggest starting a
-  new conversation.
+Both are **enforced** in the dsh app and **advisory** as a plain Agent Skill.
+Say which one you are in rather than asserting either.
+
+- **Maximum 15 pages per invocation.** In the app a wider range is denied
+  before it runs, with `PAGE_RANGE_EXCEEDED`.
+- **Maximum 90 pages per session** — a context-health budget, counted in the
+  app from successful reads folded out of the session log, and denied with
+  `PAGE_BUDGET_EXCEEDED`. It counts what went through the harness; reading
+  done outside it is invisible to the count.
+- Outside the app nothing counts for you: the limits are a rule you follow
+  imperfectly, and you should not present the budget as tracked.
+- When a request approaches the budget, say so and suggest a new session.
 
 ## Workflow
 
 1. **Identify the PDF.** If the user provides a path, use it directly. If the user names an author or title, search the project's `literature/` directory using Glob to locate the file.
-2. **Read the specified page(s)** using the Read tool with the `pages` parameter. Default to the next unread page if the user says "next page" or "continue".
+2. **Read the specified page(s).** In the dsh app call the `read_pdf` tool —
+   `file_path`, `first_page`, `last_page` — which is the surface the page
+   guards decide on. As a plain Agent Skill, use the host's own file reader
+   with whatever page selection it offers. Default to the next unread page if
+   the user says "next page" or "continue".
 3. **Display structured output** following the format below.
 4. **Wait for user instruction.** Do not proceed to the next page, take notes, or search for related material unless explicitly asked.
 

--- a/docs/skills/08-export.md
+++ b/docs/skills/08-export.md
@@ -4,4 +4,4 @@ Convert chapters and reading notes from Markdown to `.docx` and package outputs 
 
 The skill is user-invoked only. It checks conversion dependencies, runs `.claude/skills/export/scripts/convert_to_docx.py`, and reports converted files, skipped files, output path, ZIP path, and conversion method.
 
-Run `/audit`, `/style`, and `/logic-review` before exporting final material.
+Run `/audit` and `/review` before exporting final material.

--- a/guards/tests/skill-text.test.ts
+++ b/guards/tests/skill-text.test.ts
@@ -1,0 +1,111 @@
+// Gate A goal 3: a skill describes the surface it is running on.
+//
+// Several skills still described a world that no longer exists. `/read` told
+// the agent the page budget was "an advisory rule the model follows
+// imperfectly, not an enforced counter" and that the guard enforcing it would
+// ship "in P1" — it shipped, and denies with PAGE_BUDGET_EXCEEDED. `/note`
+// named `/progress`, retired from the catalogue. The export documentation
+// prescribed `/style` and `/logic-review`, which are not in it either.
+//
+// Prose cannot all be checked mechanically, but three things can, and each of
+// them is a way the text drifts from the product without anyone noticing.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const PRODUCT_ROOT = resolve(import.meta.dirname, '..', '..')
+const SKILLS_SRC = join(PRODUCT_ROOT, '.claude', 'skills')
+const SKILL_DOCS = join(PRODUCT_ROOT, 'docs', 'skills')
+
+const CATALOGUE = readdirSync(SKILLS_SRC, { withFileTypes: true })
+  .filter((e) => e.isDirectory()).map((e) => e.name).sort()
+
+/** Every file that tells a reader or an agent which skills exist. */
+function skillProse(): Array<{ where: string; body: string }> {
+  const out = CATALOGUE.map((name) => ({
+    where: `.claude/skills/${name}/SKILL.md`,
+    body: readFileSync(join(SKILLS_SRC, name, 'SKILL.md'), 'utf8'),
+  }))
+  if (existsSync(SKILL_DOCS)) {
+    for (const f of readdirSync(SKILL_DOCS).filter((n) => n.endsWith('.md'))) {
+      out.push({ where: `docs/skills/${f}`, body: readFileSync(join(SKILL_DOCS, f), 'utf8') })
+    }
+  }
+  return out
+}
+
+test('no skill or skill document sends the reader to a command outside the catalogue', () => {
+  // A retired skill keeps working as an instruction long after it stops
+  // working as a skill: nothing triggers, and the reader cannot tell whether
+  // they mistyped it or the document is stale.
+  const known = new Set(CATALOGUE)
+  const dangling: string[] = []
+  for (const { where, body } of skillProse()) {
+    for (const [, name] of body.matchAll(/(?:^|[\s(`])\/([a-z][a-z0-9-]{2,})\b/g)) {
+      if (!known.has(name)) dangling.push(`${where}: /${name}`)
+    }
+  }
+  assert.deepEqual([...new Set(dangling)].sort(), [],
+    `these name a skill the catalogue does not have:\n  ${[...new Set(dangling)].sort().join('\n  ')}`)
+})
+
+test('the notes template a workspace ships passes the lint /note declares mandatory', async () => {
+  // `/note` calls the Evidence status line required, and the template omitted
+  // it — so every notes file a new author starts from was missing the field
+  // that stops an abstract-only source being cited as evidence.
+  const { lintNotes } = await import(join(PRODUCT_ROOT, 'guards', 'dist', 'notes-lint.js'))
+  const template = readFileSync(join(PRODUCT_ROOT, 'literature', 'reading_notes', '_template_NOTES.md'), 'utf8')
+  const findings = lintNotes(template).map((f: { code: string; severity: string }) => `${f.severity}: ${f.code}`)
+  assert.deepEqual(findings, [], `the shipped template does not satisfy its own linter:\n  ${findings.join('\n  ')}`)
+})
+
+test('a skill that instructs an interpreter is granted the tool that runs it', () => {
+  // `/export` granted `Bash(python *)` while its body ran `python3`, so in a
+  // host that honours the declaration the skill's own command is refused.
+  const problems: string[] = []
+  for (const name of CATALOGUE) {
+    const body = readFileSync(join(SKILLS_SRC, name, 'SKILL.md'), 'utf8')
+    const grant = /^allowed-tools:(.*)$/m.exec(body)?.[1] ?? ''
+    const interpreters = new Set([...body.matchAll(/^\s*(python3|node|npm)\s+\S/gm)].map((m) => m[1]))
+    if (interpreters.size === 0) continue
+    if (!/\bBash\b/.test(grant)) {
+      problems.push(`${name}: instructs ${[...interpreters].join(', ')} but grants no Bash`)
+      continue
+    }
+    // A narrowed grant must cover what the body actually runs.
+    for (const scoped of grant.matchAll(/Bash\(([^)]*)\)/g)) {
+      const covers = [...interpreters].some((i) => scoped[1].trim().startsWith(i))
+      if (!covers && !/^Bash\b(?!\()/.test(grant.trim())) {
+        problems.push(`${name}: grants Bash(${scoped[1].trim()}) but instructs ${[...interpreters].join(', ')}`)
+      }
+    }
+  }
+  assert.deepEqual(problems, [], `frontmatter does not permit the skill's own commands:\n  ${problems.join('\n  ')}`)
+})
+
+test('a workspace config carries the chapter targets /map reports against', () => {
+  // `/map`'s dashboard compares word counts to per-chapter targets. The
+  // scaffolded config had none, so half of what the skill advertises had no
+  // data source and the agent had to invent targets or silently drop them.
+  //
+  // Asserted against the file `init` actually writes. An earlier version of
+  // this test parsed WORKSPACE_CONFIG out of the source with a non-greedy
+  // match, which stopped at the first escaped backtick inside the template
+  // literal and read 190 characters of a config several times that long.
+  const parent = mkdtempSync(join(tmpdir(), 'awt-skill-text-'))
+  try {
+    const ws = join(parent, 'thesis')
+    const res = spawnSync(process.execPath, [join(PRODUCT_ROOT, 'scaffold', 'awt.mjs'), 'init', ws],
+      { encoding: 'utf8', timeout: 60_000 })
+    assert.equal(res.status, 0, res.stderr)
+    const config = readFileSync(join(ws, 'AGENTS.md'), 'utf8')
+    assert.match(config, /target/i, 'the scaffolded workspace config names no chapter targets')
+    assert.match(config, /\|\s*ch1\s*\|/, 'the targets are not a table /map can read')
+  } finally {
+    rmSync(parent, { recursive: true, force: true })
+  }
+})

--- a/guards/tests/skill-text.test.ts
+++ b/guards/tests/skill-text.test.ts
@@ -15,6 +15,7 @@ import assert from 'node:assert/strict'
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { spawnSync } from 'node:child_process'
 
 const PRODUCT_ROOT = resolve(import.meta.dirname, '..', '..')
@@ -57,7 +58,7 @@ test('the notes template a workspace ships passes the lint /note declares mandat
   // `/note` calls the Evidence status line required, and the template omitted
   // it — so every notes file a new author starts from was missing the field
   // that stops an abstract-only source being cited as evidence.
-  const { lintNotes } = await import(join(PRODUCT_ROOT, 'guards', 'dist', 'notes-lint.js'))
+  const { lintNotes } = await import(pathToFileURL(join(PRODUCT_ROOT, 'guards', 'dist', 'notes-lint.js')).href)
   const template = readFileSync(join(PRODUCT_ROOT, 'literature', 'reading_notes', '_template_NOTES.md'), 'utf8')
   const findings = lintNotes(template).map((f: { code: string; severity: string }) => `${f.severity}: ${f.code}`)
   assert.deepEqual(findings, [], `the shipped template does not satisfy its own linter:\n  ${findings.join('\n  ')}`)

--- a/literature/reading_notes/_template_NOTES.md
+++ b/literature/reading_notes/_template_NOTES.md
@@ -3,7 +3,11 @@
 **Source**: {single-line citation matching your project's `Citation style:` declared in `CLAUDE.md`; see "Source format examples" below}
 **Date read**: {YYYY-MM-DD}
 **Status**: reading
+**Evidence status**: metadata_only
 **Relevance**: {e.g. Ch3 S3.2 — supports argument about X}
+
+<!-- Evidence status starts at the weakest claim. Raise it to abstract_only or
+     full_text once you have actually read that much of the source. -->
 
 ---
 

--- a/scaffold/awt.mjs
+++ b/scaffold/awt.mjs
@@ -78,6 +78,19 @@ toolkit development files never belong here.
 - No chapter write may cite a source without a conforming notes file
 - Text inside quotation spans of existing chapters is immutable
 
+## Chapter targets
+Edit this table; \`/map\` reports word counts against it. Delete rows you do
+not need — an empty table means the dashboard has nothing to report against.
+
+| Chapter | Title | Target words |
+|---------|-------|--------------|
+| ch1 | Introduction | 5000 |
+| ch2 | Background | 10000 |
+| ch3 | Methodology | 8000 |
+| ch4 | Results | 12000 |
+| ch5 | Discussion | 10000 |
+| ch6 | Conclusion | 5000 |
+
 ## Writing principles (advisory)
 - Read first, write later — complete reading notes before editing chapters
 - One notes file per source, following the template format


### PR DESCRIPTION
Implements item 3 of the Gate A spec. Items 4 and 5 remain.

## Two skills told the agent the opposite of what the product does

`/read` said the 90-page budget was "an advisory rule the model follows
imperfectly, not an enforced counter" and that the guard would ship "in P1".
It shipped. `/edit-contract` said the same of Scope — *"the P1 guard enforces
Scope… Do not describe it as enforced"* — while `CONTRACT_SCOPE` and the
`ESCALATION_REQUIRED` ask are both live.

An agent following either would have assured the author that a denial could
not happen while the denial was happening.

Both now state the constraint is **enforced in the app and advisory as a plain
Agent Skill**, and say which surface they are on. That is what goal 3 asks
for — not a blanket claim in the other direction.

`/read` also told the agent to page PDFs with the host file reader's `pages`
parameter. The profile registers `read_pdf(file_path, first_page, last_page)`,
and that tool is the only surface the page guards decide on. Parameter names
and denial codes were checked against the plugin and the vocabulary rather
than written from memory.

## Four smaller drifts

| Where | Was |
| --- | --- |
| `/note` | named `/progress`, retired in the P0 triage |
| `docs/skills/08-export.md` | prescribed `/style` and `/logic-review`, neither in the catalogue |
| `/export` frontmatter | granted `Bash(python *)` while the body runs `python3` |
| the shipped notes template | failed the lint `/note` calls mandatory |

A retired skill keeps working as an *instruction* long after it stops working
as a skill: nothing triggers, and the reader cannot tell whether they mistyped
it or the document is stale.

The template now carries the weakest valid Evidence status. Any default is a
claim made on the author's behalf, and `metadata_only` is the one that cannot
over-state the evidence behind a citation — which is the failure the field
exists to prevent.

`awt init` also writes the chapter targets `/map` reports against. Half of what
that skill advertises had no data source in a fresh workspace, so the agent had
to invent targets or silently drop the dashboard.

## Gates

Three of the four new gates were red first: no skill names a command outside
the catalogue; the shipped template passes its own linter; a skill that
instructs an interpreter is granted the tool that runs it.

The fourth asserts the targets table **against the workspace `init` actually
writes**. Its first version parsed `WORKSPACE_CONFIG` out of the source with a
non-greedy match, which stopped at an escaped backtick inside the template
literal and read 190 characters of a string several times that long — it would
have passed while proving nothing. That is the sort of green this suite exists
to refuse, so it is recorded rather than quietly corrected.

The two prose corrections are not mechanically pinned, and are not claimed to
be.

```
guards 139/139 · make test 132/132 · e2e · credential · skill-scope · e1 offline
```

Each status read on its own rather than through a pipe.

E0. Nothing here is E2, and §7 verification — one pass of the daily loop from a
fresh clone producing a real `.docx`, repeated on Windows — has still not been
run.
