### PR TITLE
Gate A item 4: the ten-minute demo runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ Local discovery paths:
 
 ## Run the 10-minute demo
 
-The demo uses fictional public-safe sources. It exercises the same validators used by real projects without requiring network access.
+The demo uses fictional public-safe sources and the same validators real
+projects use. It needs the network once, to install the guards' dependencies;
+everything after that runs against local fixtures.
 
 ```bash
 python3 .claude/skills/verify-refs/scripts/verify-refs.py \
@@ -216,6 +218,9 @@ Safe fixers are deliberately narrow. They may normalise conservative citation pu
 ## Deterministic quality gates
 
 ```bash
+make setup              # once per clone: configs, export backend, doctor
+npm --prefix guards install   # once per clone: guards/node_modules is not committed
+
 make doctor             # read-only environment and project health
 make test               # regression suite
 

--- a/guards/src/notes-lint.ts
+++ b/guards/src/notes-lint.ts
@@ -6,6 +6,7 @@
 // source of truth for "does this file conform".
 
 import { readFileSync } from 'node:fs'
+import { isAbsolute, resolve as resolvePath } from 'node:path'
 
 export type Severity = 'error' | 'warning'
 
@@ -102,7 +103,22 @@ if (invokedAsCli) {
   let failed = false
   const report: Record<string, LintIssue[]> = {}
   for (const file of files) {
-    const issues = lintNotes(readFileSync(file, 'utf8'))
+    // `npm --prefix guards run` executes with the working directory set to
+    // guards/, so a path the reader wrote relative to where they typed the
+    // command would not resolve. npm exports the invoking directory as
+    // INIT_CWD; resolving against it makes the path mean what it looks like.
+    const target = isAbsolute(file) ? file : resolvePath(process.env.INIT_CWD ?? process.cwd(), file)
+    let source: string
+    try {
+      source = readFileSync(target, 'utf8')
+    } catch {
+      // A stack trace cannot be told apart from a broken install by the
+      // person who mistyped a path.
+      console.error(`lint:notes: cannot read ${file}`)
+      failed = true
+      continue
+    }
+    const issues = lintNotes(source)
     report[file] = issues
     if (hasErrors(issues)) failed = true
     if (!json) {

--- a/guards/tests/notes-lint-cli.test.ts
+++ b/guards/tests/notes-lint-cli.test.ts
@@ -25,22 +25,34 @@ const DEMO_NOTES = 'examples/demo-project/literature/reading_notes/smith2024_NOT
 const dirs: string[] = []
 after(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }) })
 
-/** The demo's command, run exactly as the README prints it. */
+/**
+ * The demo's command, run exactly as the README prints it. npm is a .cmd shim
+ * on Windows and Node refuses to spawn one without a shell since the fix for
+ * CVE-2024-27980, so the argument that can contain spaces is quoted there.
+ */
 function lintFromRepoRoot(...args: string[]) {
-  return spawnSync('npm', ['--prefix', 'guards', 'run', '--silent', 'lint:notes', '--', ...args],
-    { cwd: PRODUCT_ROOT, encoding: 'utf8', timeout: 300_000 })
+  const onWindows = process.platform === 'win32'
+  const passed = onWindows ? args.map((a) => `"${a}"`) : args
+  return spawnSync(onWindows ? 'npm.cmd' : 'npm',
+    ['--prefix', 'guards', 'run', '--silent', 'lint:notes', '--', ...passed],
+    { cwd: PRODUCT_ROOT, encoding: 'utf8', timeout: 300_000, shell: onWindows })
+}
+
+/** Everything a failed run said, including why a spawn never started. */
+function saidBy(res: { stdout?: string; stderr?: string; error?: Error }): string {
+  return `${res.stdout ?? ''}${res.stderr ?? ''}${res.error ? `\n${res.error.message}` : ''}`
 }
 
 test('the demo command lints a repo-relative path from the repository root', () => {
   const res = lintFromRepoRoot(DEMO_NOTES)
-  assert.equal(res.status, 0, `the README's own command failed:\n${res.stdout}${res.stderr}`)
+  assert.equal(res.status, 0, `the README's own command failed:\n${saidBy(res)}`)
 })
 
 test('a path that does not exist is a message, not a stack trace', () => {
   // The reader of a stack trace cannot tell a wrong path from a broken install.
   const res = lintFromRepoRoot('literature/reading_notes/no-such-file_NOTES.md')
   assert.notEqual(res.status, 0)
-  const output = res.stdout + res.stderr
+  const output = saidBy(res)
   assert.doesNotMatch(output, /at readFileSync|at ModuleJob|node:internal/, `raw stack trace:\n${output}`)
   assert.match(output, /no-such-file_NOTES\.md/, 'the message should name the file it could not read')
 })
@@ -53,6 +65,6 @@ test('an absolute path still works, and INIT_CWD does not override it', () => {
   const res = lintFromRepoRoot(file)
   // Content is wrong, so it fails — but on the content, having found the file.
   assert.notEqual(res.status, 0)
-  assert.match(res.stdout + res.stderr, /absolute_NOTES\.md/)
-  assert.doesNotMatch(res.stdout + res.stderr, /ENOENT/)
+  assert.match(saidBy(res), /absolute_NOTES\.md/)
+  assert.doesNotMatch(saidBy(res), /ENOENT/)
 })

--- a/guards/tests/notes-lint-cli.test.ts
+++ b/guards/tests/notes-lint-cli.test.ts
@@ -1,0 +1,58 @@
+// Gate A item 4: the README's ten-minute demo has to run.
+//
+// Its third command was `npm --prefix guards run lint:notes -- examples/…`.
+// `--prefix` runs the script with the working directory set to `guards/`, so a
+// path written relative to the repository root does not resolve, and the
+// linter died with a raw Node stack trace naming a file the reader can see is
+// there. The demo is the first thing the README offers, and it failed on a
+// correct checkout.
+//
+// Fixed in the tool rather than the prose: npm exports INIT_CWD as the
+// directory it was invoked from, so a relative argument resolves against the
+// place the reader typed it. That fixes the whole class, not the one command
+// the README happened to print.
+
+import { test, after } from 'node:test'
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const PRODUCT_ROOT = resolve(import.meta.dirname, '..', '..')
+const DEMO_NOTES = 'examples/demo-project/literature/reading_notes/smith2024_NOTES.md'
+
+const dirs: string[] = []
+after(() => { for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true }) })
+
+/** The demo's command, run exactly as the README prints it. */
+function lintFromRepoRoot(...args: string[]) {
+  return spawnSync('npm', ['--prefix', 'guards', 'run', '--silent', 'lint:notes', '--', ...args],
+    { cwd: PRODUCT_ROOT, encoding: 'utf8', timeout: 300_000 })
+}
+
+test('the demo command lints a repo-relative path from the repository root', () => {
+  const res = lintFromRepoRoot(DEMO_NOTES)
+  assert.equal(res.status, 0, `the README's own command failed:\n${res.stdout}${res.stderr}`)
+})
+
+test('a path that does not exist is a message, not a stack trace', () => {
+  // The reader of a stack trace cannot tell a wrong path from a broken install.
+  const res = lintFromRepoRoot('literature/reading_notes/no-such-file_NOTES.md')
+  assert.notEqual(res.status, 0)
+  const output = res.stdout + res.stderr
+  assert.doesNotMatch(output, /at readFileSync|at ModuleJob|node:internal/, `raw stack trace:\n${output}`)
+  assert.match(output, /no-such-file_NOTES\.md/, 'the message should name the file it could not read')
+})
+
+test('an absolute path still works, and INIT_CWD does not override it', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'awt-lint-cli-'))
+  dirs.push(dir)
+  const file = join(dir, 'absolute_NOTES.md')
+  writeFileSync(file, 'not a notes file')
+  const res = lintFromRepoRoot(file)
+  // Content is wrong, so it fails — but on the content, having found the file.
+  assert.notEqual(res.status, 0)
+  assert.match(res.stdout + res.stderr, /absolute_NOTES\.md/)
+  assert.doesNotMatch(res.stdout + res.stderr, /ENOENT/)
+})


### PR DESCRIPTION
Implements item 4 of the Gate A spec. Item 5 remains.

## The demo failed on a correct checkout

The README's third demo command was `npm --prefix guards run lint:notes -- examples/…`. `--prefix` runs the script with the working directory set to `guards/`, so a path written relative to the repository root did not resolve, and the linter died with a raw Node stack trace naming a file the reader can see is there.

It is the first thing the README offers after setup.

## Fixed in the tool, not the prose

npm exports the invoking directory as `INIT_CWD`, so a relative argument now resolves against the place the reader typed it. That fixes the class — any `npm --prefix guards run <script> -- <relative path>` — rather than the one command the README happened to print.

A file that cannot be read is now a one-line message naming it. A stack trace cannot be told apart from a broken install by the person who mistyped a path.

## Two claims on the same page were untrue

- The demo said it runs "without requiring network access", three lines above `npm --prefix guards install`, which fetches 33 packages.
- The quality-gates block listed `npm --prefix guards test` without the install it needs. On a fresh clone that exits **127** with `sh: tsc: command not found` — verified by cloning and running it, before (127) and after (0).

## Gates

Three new, two red first: the demo's own command from the repository root; a missing path producing a message rather than a stack; and an absolute path still resolving, so `INIT_CWD` does not quietly redirect one.

```
guards 142/142 · make test 132/132 · e2e · credential · skill-scope · e1 offline
```

Each status read on its own.