### PR TITLE
Salvage from codex/research-skill-reconciliation, and close the rest out

### DIFF
--- a/.claude/skills/read/SKILL.md
+++ b/.claude/skills/read/SKILL.md
@@ -24,7 +24,9 @@ Say which one you are in rather than asserting either.
 - **Maximum 90 pages per session** — a context-health budget, counted in the
   app from successful reads folded out of the session log, and denied with
   `PAGE_BUDGET_EXCEEDED`. It counts what went through the harness; reading
-  done outside it is invisible to the count.
+  done outside it is invisible to the count. The fold counts calls, not
+  distinct pages, so re-reading a page you already read spends the budget
+  again — say so before repeating a range.
 - Outside the app nothing counts for you: the limits are a rule you follow
   imperfectly, and you should not present the budget as tracked.
 - When a request approaches the budget, say so and suggest a new session.

--- a/guards/tests/skill-text.test.ts
+++ b/guards/tests/skill-text.test.ts
@@ -110,3 +110,22 @@ test('a workspace config carries the chapter targets /map reports against', () =
     rmSync(parent, { recursive: true, force: true })
   }
 })
+
+test('the evidence-status values skills name are the ones the linter accepts', () => {
+  // `/note` declares the field, the shipped template carries it, and
+  // `/integrate` refuses to weave in a source that reports having been read
+  // only in part. Three places naming one vocabulary is three places for it
+  // to drift from the one that enforces it.
+  const accepted = /const EVIDENCE_VALUES = \[([^\]]*)\]/
+    .exec(readFileSync(join(PRODUCT_ROOT, 'guards', 'src', 'notes-lint.ts'), 'utf8'))?.[1]
+  assert.ok(accepted, 'EVIDENCE_VALUES not found in the linter')
+  const known = new Set([...accepted.matchAll(/'([a-z_]+)'/g)].map((m) => m[1]))
+
+  const wrong: string[] = []
+  for (const { where, body } of skillProse()) {
+    for (const [, value] of body.matchAll(/Evidence status[`:\s]*([a-z_]{4,})/g)) {
+      if (!known.has(value)) wrong.push(`${where}: ${value}`)
+    }
+  }
+  assert.deepEqual(wrong, [], `these name a value the linter would reject:\n  ${wrong.join('\n  ')}`)
+})


### PR DESCRIPTION
`codex/research-skill-reconciliation-20260907` carries 102 files against a main from 2026-09-02. It was reviewed file by file against current main rather than merged, because most of it cannot land:

| part | files | why |
| --- | ---: | --- |
| the retired plugin package | 40 | decommissioned with v0.1 |
| skills the P0 triage removed | ~32 | `style`, `thesis-control`, `argument-governance`, `release-governance`… |
| its test additions | — | assert against `.claude/skills/{thesis-control,argument-governance,release-governance}`, which do not exist |

## Most of the rest already arrived

`/integrate`'s evidence-status gate is **byte-identical to main** — it landed with an earlier merge. `/audit`'s disclosure of the disabled legacy citation tiers is already there too; the branch's version of `/audit` would *remove* 72 lines of what Gate A item 3 wrote.

Its `/map` and `/note` improvements depend on `.claude/skills/progress/`, a retired skill. Taking them would either restore a tenth catalogue entry — which the Gate A spec lists as a non-goal — or relocate those assets into the calling skill. That is a real option, and it is a product decision rather than a salvage.

## One thing was genuinely new

A page read twice spends the budget twice. Taken with attribution, and **verified against the shipped fold rather than accepted on the description**: `pageBudgetProjection` dedupes by `callId`, not by page range, so two calls covering the same page cost two.

## The drift gate is mine

Three places now name the evidence-status vocabulary — `/note` declares it, the shipped template carries it, `/integrate` acts on it — and only `notes-lint.ts` enforces it. The gate fails if any of them names a value the linter would reject.

```
guards 0 · make test 0
```