### PR TITLE
Gate A item 5: one active contract, or a refusal that names them

### DIFF
--- a/.claude/skills/edit-contract/SKILL.md
+++ b/.claude/skills/edit-contract/SKILL.md
@@ -30,8 +30,6 @@ section claims, restructuring). Not for typo fixes or single-sentence edits.
 
 ## Attempts
 - [ ] Attempt 1: {date} — {outcome: accepted / revise / rejected, one line why}
-- [ ] Attempt 2: …
-- [ ] Attempt 3: …
 ```
 
 ## Workflow
@@ -56,7 +54,15 @@ produce a fourth patch under the old contract.
 
 ## Constraints
 
-1. One contract file per edit goal; append-only Attempts.
+1. One contract file per edit goal; append-only Attempts. Append the next
+   attempt line as you make it rather than pre-writing empty ones.
+
+   **Retiring a contract.** A contract is active while any `- [ ] Attempt`
+   line is unticked, and an active contract scopes every chapter write. When
+   the goal is done or abandoned, tick its attempts — that retires it. Leaving
+   a finished contract active makes it scope tomorrow's work as well, and two
+   active contracts at once are refused with `CONTRACT_AMBIGUOUS` naming both,
+   because the guard cannot know which one an edit belongs to.
 2. Never edit outside Scope; never touch quoted spans.
 3. In the dsh app this is **enforced**: a write outside Scope is denied with
    `CONTRACT_SCOPE`, and after three typed denials under one contract the next

--- a/guards/README.md
+++ b/guards/README.md
@@ -15,7 +15,8 @@ pinned harness by the testkit tier and the live e2e.
 | --- | --- | --- | --- |
 | No chapter write may cite a source without a conforming notes file | `ctx.tools.guard` | author-year citations extracted from the written/inserted text, matched against lint-conforming `literature/reading_notes/*_NOTES.md` | deny `NOTES_MISSING` |
 | Quoted text in existing chapters is immutable | `ctx.tools.guard` | quotation-delimited spans of the target file before vs after the proposed write/edit | deny `QUOTE_SPAN_MODIFIED` |
-| Chapter writes stay inside the active edit contract's scope | `ctx.tools.guard` | target path against the on-disk active contract's `May change:` / `Must not change:` lists | deny `CONTRACT_SCOPE` |
+| Chapter writes stay inside the active edit contract's scope | `ctx.tools.guard` | target path against the one on-disk active contract's `May change:` / `Must not change:` lists | deny `CONTRACT_SCOPE` |
+| Exactly one edit contract may be active at a time | `ctx.tools.guard` | contracts under `contracts/` still carrying an unticked `- [ ] Attempt` | deny `CONTRACT_AMBIGUOUS` |
 | ≤ 15 pages per `read_pdf` invocation | `ctx.tools.guard` | `first_page`..`last_page` of the requested call | deny `PAGE_RANGE_EXCEEDED` |
 | ≤ 90 pages per session | `ctx.tools.guard` | successful `read_pdf` results folded from the append-only session log (page-budget projection) | deny `PAGE_BUDGET_EXCEEDED` |
 | After 3 typed-denial attempts under a contract, further in-scope chapter writes need the author | `tools/pre-execute` waterfall | per-contract typed-denial attempts folded from the session log (revision-attempts projection) | `ask` with reason `ESCALATION_REQUIRED`, resolved by dsh-user-approval (`allowed-once` / `rejected` / fail-closed `unavailable`) |
@@ -41,7 +42,11 @@ events. No agent-writable file is ever an authority.
   logged writes/edits only; it cannot restore a file rewritten outside dsh,
   and deleting a whole span visibly is allowed by design.
 - **Contract-scope guard**: scope comes from the on-disk active contract at
-  decision time. Contract lifecycle changes through logged writes are
+  decision time. A contract is active while any `- [ ] Attempt` line is
+  unticked, so a finished contract keeps scoping work until its attempts are
+  ticked. Two active at once are refused by name rather than resolved: the
+  guard has no way to know which one an edit belongs to, and choosing by
+  directory order silently decided what the author was allowed to change. Contract lifecycle changes through logged writes are
   legitimate management, not bypass; a contract file placed or edited
   outside dsh still scopes writes but never arms the escalation fold.
 - **Page budget**: counts successful logged `read_pdf` results. It cannot

--- a/guards/src/decisions.ts
+++ b/guards/src/decisions.ts
@@ -29,7 +29,13 @@ export interface RepoView {
   /** first-author surname (lowercase) + year for every lint-conforming notes file. */
   conformingSources(): ReadonlyArray<{ surname: string; year: string }>
   /** Active contract scopes (contracts/*.md with an unchecked attempt box), if any. */
-  activeContract(): { path?: string; mayChange: string[]; mustNotChange: string[] } | undefined
+  /**
+   * Every contract still carrying an unticked attempt, in no guaranteed order.
+   * Plural on purpose: picking one of several by directory order is a silent
+   * choice about what the author may edit, and the guard cannot know which
+   * one they meant.
+   */
+  activeContracts(): Array<{ path?: string; mayChange: string[]; mustNotChange: string[] }>
   /** Project-relative paths of every chapter file (chapters/**.md) — corpus-wide checks. */
   chapterFiles(): string[]
   /** The workspace bibliography (references.bib at the root, else the first root-level .bib), if any. */
@@ -150,13 +156,25 @@ export function decideContractScope(call: ToolCall, repo: RepoView): Denial | un
   const rel = repo.relative(raw)
   if (!rel || !isChapterPath(rel)) return undefined
   if (call.tool !== 'write' && call.tool !== 'edit') return undefined
-  const contract = repo.activeContract()
-  if (!contract) return undefined
+  const contracts = repo.activeContracts()
+  if (contracts.length === 0) return undefined
+  // Checked before scope, so an in-scope path cannot mask the ambiguity: a
+  // write that happens to fall inside yesterday's contract would otherwise
+  // pass silently while the author believed today's was in force.
+  if (contracts.length > 1) {
+    const named = contracts.map((c) => c.path ?? '(unnamed contract)').sort().join(', ')
+    return {
+      code: 'CONTRACT_AMBIGUOUS',
+      message: `${contracts.length} edit contracts are active at once (${named}); retire all but the one this edit belongs to by ticking its attempts.`,
+    }
+  }
+  const contract = contracts[0]
+  const which = contract.path ? `"${contract.path}"` : 'the active edit contract'
   if (underAny(rel, contract.mustNotChange)) {
-    return { code: 'CONTRACT_SCOPE', message: `"${rel}" is listed under "Must not change" in the active edit contract.` }
+    return { code: 'CONTRACT_SCOPE', message: `"${rel}" is listed under "Must not change" in ${which}.` }
   }
   if (contract.mayChange.length > 0 && !underAny(rel, contract.mayChange)) {
-    return { code: 'CONTRACT_SCOPE', message: `"${rel}" is outside the active edit contract's "May change" scope.` }
+    return { code: 'CONTRACT_SCOPE', message: `"${rel}" is outside the "May change" scope of ${which}.` }
   }
   return undefined
 }

--- a/guards/src/dsh-plugin.ts
+++ b/guards/src/dsh-plugin.ts
@@ -160,16 +160,20 @@ export function fsRepoView(projectRoot: string): RepoView {
       }
       return out
     },
-    activeContract() {
+    activeContracts() {
       const dir = join(root, 'contracts')
-      if (!existsSync(dir)) return undefined
-      for (const name of readdirSync(dir)) {
+      if (!existsSync(dir)) return []
+      // Every active one, not the first in directory order. Returning one of
+      // several let yesterday's contract scope today's writes, and which one
+      // won depended on how the names happened to sort.
+      const out = []
+      for (const name of readdirSync(dir).sort()) {
         if (!name.endsWith('.md')) continue
         const parsed = parseContractSource(readFileSync(join(dir, name), 'utf8'))
         if (!parsed.active) continue
-        return { path: `contracts/${name}`, mayChange: parsed.mayChange, mustNotChange: parsed.mustNotChange }
+        out.push({ path: `contracts/${name}`, mayChange: parsed.mayChange, mustNotChange: parsed.mustNotChange })
       }
-      return undefined
+      return out
     },
     chapterFiles() {
       const out: string[] = []
@@ -339,8 +343,10 @@ export function apply(ctx: GuardHostContext, config?: Config): void {
     // keyed by the on-disk active contract. Over-counts untyped failures as
     // strikes — the conservative, ask-earlier direction — and is never
     // consulted when the projection snapshot is available.
-    const contract = repoFor(execution).activeContract()
-    if (contract?.path === undefined) return undefined
+    const active = repoFor(execution).activeContracts()
+    if (active.length !== 1) return undefined
+    const contract = active[0]
+    if (contract.path === undefined) return undefined
     const denied = fallbackDenied.get(contract.path) ?? 0
     return denied >= REVISION_ESCALATION_THRESHOLD ? { contract: contract.path, denied } : undefined
   }
@@ -359,9 +365,9 @@ export function apply(ctx: GuardHostContext, config?: Config): void {
     if (result.isError) {
       const rel = typeof call.args.file_path === 'string' ? repo.relative(call.args.file_path) : undefined
       if (rel !== undefined && rel.startsWith('chapters/') && (call.tool === 'write' || call.tool === 'edit')) {
-        const contract = repo.activeContract()
-        if (contract?.path !== undefined) {
-          fallbackDenied.set(contract.path, (fallbackDenied.get(contract.path) ?? 0) + 1)
+        const active = repo.activeContracts()
+        if (active.length === 1 && active[0].path !== undefined) {
+          fallbackDenied.set(active[0].path, (fallbackDenied.get(active[0].path) ?? 0) + 1)
         }
       }
       return

--- a/guards/src/vocabulary.ts
+++ b/guards/src/vocabulary.ts
@@ -22,7 +22,7 @@
 // --- denial codes -------------------------------------------------------------
 
 /** Chapter-write guard denial codes (P1 session 1). */
-export const CHAPTER_DENIAL_CODES = ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE'] as const
+export const CHAPTER_DENIAL_CODES = ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE', 'CONTRACT_AMBIGUOUS'] as const
 export type ChapterDenialCode = (typeof CHAPTER_DENIAL_CODES)[number]
 
 /** read_pdf page-budget denial codes (P1 session 2). */

--- a/guards/tests/contract-lifecycle.test.ts
+++ b/guards/tests/contract-lifecycle.test.ts
@@ -1,0 +1,113 @@
+// Gate A item 5: yesterday's contract must not silently scope today's writes.
+//
+// A contract is "active" while it still carries an unchecked `- [ ] Attempt`
+// line, and the skill's template ships three of them. So a contract is active
+// from the moment it is written and stays active until the author ticks every
+// box — which nothing told them to do. `activeContract()` then returned the
+// FIRST active contract in readdir order, not the newest.
+//
+// The loop therefore worked on day one and denied on day two: chapter writes
+// were scoped against a contract the author was not working under, and the
+// denial said "the active edit contract" without naming which one, so there
+// was nothing to act on.
+//
+// Two active contracts is not a state the guard can resolve. Picking one by
+// directory order is a silent choice about what the author may edit, which is
+// the kind of thing this product refuses rather than guesses.
+
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+import { decideContractScope, type RepoView } from '../src/decisions.ts'
+
+const PRODUCT_ROOT = resolve(import.meta.dirname, '..', '..')
+
+function repo(overrides: Partial<RepoView> = {}): RepoView {
+  return {
+    relative: (p) => (p.startsWith('/') ? undefined : p),
+    readFile: () => undefined,
+    conformingSources: () => [],
+    activeContracts: () => [],
+    chapterFiles: () => [],
+    bibText: () => undefined,
+    ...overrides,
+  } as RepoView
+}
+
+const YESTERDAY = { path: 'contracts/2026-09-06-ch3.md', mayChange: ['chapters/ch3.md'], mustNotChange: [] }
+const TODAY = { path: 'contracts/2026-09-07-ch5.md', mayChange: ['chapters/ch5.md'], mustNotChange: [] }
+
+test('two active contracts are a typed refusal, not a silent choice between them', () => {
+  const d = decideContractScope(
+    { tool: 'write', args: { file_path: 'chapters/ch5.md', content: 'x' } },
+    repo({ activeContracts: () => [YESTERDAY, TODAY] }),
+  )
+  assert.equal(d?.code, 'CONTRACT_AMBIGUOUS')
+  // The author cannot retire one without being told which two.
+  assert.match(d!.message, /2026-09-06-ch3\.md/)
+  assert.match(d!.message, /2026-09-07-ch5\.md/)
+})
+
+test('the refusal comes before the scope decision, so it cannot be masked by an in-scope path', () => {
+  // Writing inside YESTERDAY's scope would have passed silently while TODAY
+  // was the contract the author believed they were working under.
+  const d = decideContractScope(
+    { tool: 'write', args: { file_path: 'chapters/ch3.md', content: 'x' } },
+    repo({ activeContracts: () => [YESTERDAY, TODAY] }),
+  )
+  assert.equal(d?.code, 'CONTRACT_AMBIGUOUS')
+})
+
+test('one active contract scopes as before, and the denial names it', () => {
+  const d = decideContractScope(
+    { tool: 'write', args: { file_path: 'chapters/ch9.md', content: 'x' } },
+    repo({ activeContracts: () => [TODAY] }),
+  )
+  assert.equal(d?.code, 'CONTRACT_SCOPE')
+  assert.match(d!.message, /2026-09-07-ch5\.md/, 'the denial must say which contract decided')
+})
+
+test('retiring one leaves the other in charge', () => {
+  assert.equal(
+    decideContractScope(
+      { tool: 'write', args: { file_path: 'chapters/ch5.md', content: 'x' } },
+      repo({ activeContracts: () => [TODAY] }),
+    ),
+    undefined,
+  )
+})
+
+test('no active contract is still no scope restriction', () => {
+  assert.equal(
+    decideContractScope(
+      { tool: 'write', args: { file_path: 'chapters/anything.md', content: 'x' } },
+      repo({ activeContracts: () => [] }),
+    ),
+    undefined,
+  )
+})
+
+test('the shipped contract template does not leave a finished contract active', async () => {
+  // The template shipped three unchecked Attempt lines, so a contract stayed
+  // active after the work was done and shadowed the next one. Whatever the
+  // template ships, a contract written from it and then completed must be
+  // retireable by the author without guessing how.
+  const { parseContractSource } = await import(
+    pathToFileURL(join(PRODUCT_ROOT, 'guards', 'dist', 'projections.js')).href
+  )
+  const skill = await import('node:fs').then((fs) =>
+    fs.readFileSync(join(PRODUCT_ROOT, '.claude', 'skills', 'edit-contract', 'SKILL.md'), 'utf8'))
+  const template = /```markdown\n([\s\S]*?)```/.exec(skill)?.[1]
+  assert.ok(template, 'no contract template found in the skill')
+
+  const unchecked = [...template.matchAll(/^- \[ \] Attempt/gm)].length
+  assert.equal(unchecked, 1, `the template ships ${unchecked} pre-written attempts; a finished contract keeps every unticked one active`)
+  assert.equal(parseContractSource(template).active, true, 'a fresh contract must be active')
+  assert.equal(parseContractSource(template.replace('- [ ]', '- [x]')).active, false,
+    'ticking the attempt must retire the contract')
+  assert.match(skill, /retire|retiring/i, 'the skill must say how a contract is retired')
+})

--- a/guards/tests/decisions.test.ts
+++ b/guards/tests/decisions.test.ts
@@ -16,7 +16,7 @@ function repo(overrides: Partial<RepoView> = {}): RepoView {
     relative: (p) => (p.startsWith('/') ? undefined : p),
     readFile: () => undefined,
     conformingSources: () => [{ surname: 'smith', year: '2024' }],
-    activeContract: () => undefined,
+    activeContracts: () => [],
     chapterFiles: () => [],
     bibText: () => undefined,
     ...overrides,
@@ -91,7 +91,7 @@ const CONTRACT = { mayChange: ['chapters/ch3.md'], mustNotChange: ['chapters/ch4
 test('write outside the active contract May-change scope is denied', () => {
   const d = decideContractScope(
     { tool: 'write', args: { file_path: 'chapters/ch5.md', content: 'x' } },
-    repo({ activeContract: () => CONTRACT })
+    repo({ activeContracts: () => [CONTRACT] })
   )
   assert.equal(d?.code, 'CONTRACT_SCOPE')
 })
@@ -99,14 +99,14 @@ test('write outside the active contract May-change scope is denied', () => {
 test('write to a Must-not-change path is denied even if also under May-change', () => {
   const d = decideContractScope(
     { tool: 'edit', args: { file_path: 'chapters/ch4.md', old_string: 'a', new_string: 'b' } },
-    repo({ activeContract: () => ({ mayChange: ['chapters/'], mustNotChange: ['chapters/ch4.md'] }) })
+    repo({ activeContracts: () => [{ mayChange: ['chapters/'], mustNotChange: ['chapters/ch4.md'] }] })
   )
   assert.equal(d?.code, 'CONTRACT_SCOPE')
 })
 
 test('in-scope write passes; no active contract means no scope restriction', () => {
   assert.equal(
-    decideContractScope({ tool: 'write', args: { file_path: 'chapters/ch3.md', content: 'x' } }, repo({ activeContract: () => CONTRACT })),
+    decideContractScope({ tool: 'write', args: { file_path: 'chapters/ch3.md', content: 'x' } }, repo({ activeContracts: () => [CONTRACT] })),
     undefined
   )
   assert.equal(
@@ -120,7 +120,7 @@ test('in-scope write passes; no active contract means no scope restriction', () 
 test('decide() reports contract scope before quote/notes issues', () => {
   const d = decide(
     { tool: 'write', args: { file_path: 'chapters/ch5.md', content: 'Jones (2021)' } },
-    repo({ activeContract: () => CONTRACT })
+    repo({ activeContracts: () => [CONTRACT] })
   )
   assert.equal(d?.code, 'CONTRACT_SCOPE')
 })

--- a/guards/tests/vocabulary.test.ts
+++ b/guards/tests/vocabulary.test.ts
@@ -20,11 +20,11 @@ import {
   revisionAttemptsSchema,
 } from '../src/vocabulary.ts'
 
-test('the denial-code catalogue is exactly the six codes — five from P1 plus the P4 export gate', () => {
-  assert.deepEqual([...CHAPTER_DENIAL_CODES], ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE'])
+test('the denial-code catalogue is exactly the seven codes — five from P1, the P4 export gate, and the Gate A contract ambiguity', () => {
+  assert.deepEqual([...CHAPTER_DENIAL_CODES], ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE', 'CONTRACT_AMBIGUOUS'])
   assert.deepEqual([...PAGE_DENIAL_CODES], ['PAGE_RANGE_EXCEEDED', 'PAGE_BUDGET_EXCEEDED'])
   assert.deepEqual([...EXPORT_DENIAL_CODES], ['EXPORT_SOURCES_UNRESOLVED'])
-  assert.equal(ALL_DENIAL_CODES.length, 6)
+  assert.equal(ALL_DENIAL_CODES.length, 7)
   // ESCALATION_REQUIRED must NOT be claimed until the session-2 ask seam ships.
   assert.ok(!(ALL_DENIAL_CODES as readonly string[]).includes('ESCALATION_REQUIRED'))
 })


### PR DESCRIPTION
Implements item 5, the last of the Gate A spec.

## Yesterday's contract silently scoped today's writes

A contract is active while any `- [ ] Attempt` line is unticked, and the skill's template shipped **three**. So a contract was active from the moment it was written and stayed active until the author ticked every box — which nothing told them to do. `activeContract()` then returned the **first** active contract in directory order.

The loop therefore worked on day one and denied on day two. Which contract won depended on how the filenames happened to sort, and the denial said *"the active edit contract"* without naming which one, so there was nothing to act on.

## Two active contracts is a refusal, not a choice

Choosing one by directory order is a silent decision about what the author may change. It is now `CONTRACT_AMBIGUOUS`, naming both and saying how to retire one.

The check runs **before** the scope test on purpose: a write that happens to fall inside yesterday's scope would otherwise pass silently while today's contract was the one the author believed was in force. That case has its own test.

With exactly one active contract the behaviour is unchanged, except the denial now names the contract that decided.

## The template was the trap

It ships one attempt line rather than three pre-written empty ones, and the skill now says what retiring a contract means and why leaving one active scopes tomorrow's work. A test pins the property rather than the wording: whatever the template ships, a fresh contract must parse as active and a ticked one must not.

The escalation counter and its registry-less fallback both count per contract, so they stand down when there is no single active contract — the write is denied anyway.

## Vocabulary

Six codes to seven. The canonical pin in `vocabulary.test.ts` is **updated rather than duplicated** — the new suite asserts behaviour, and one place owns the catalogue.

## Evidence

Verified in a real workspace, not only through the kernel:

```
two contracts  → CONTRACT_AMBIGUOUS: 2 edit contracts are active at once
                 (contracts/2026-09-06-ch3.md, contracts/2026-09-07-ch5.md);
                 retire all but the one this edit belongs to…
tick one       → CONTRACT_SCOPE: "chapters/ch3.md" is outside the "May change"
                 scope of "contracts/2026-09-07-ch5.md"
```

```
guards 151/151 · make test 132/132 · e2e · credential · skill-scope · e1 offline
```

Each status read on its own. E0 — §7 verification of Gate A, one pass of the daily loop from a fresh clone producing a real `.docx` and repeated on Windows, still has not been run.