### PR TITLE
A contract scope the guard cannot read is a refusal, not a guess

### DIFF
--- a/.claude/skills/edit-contract/SKILL.md
+++ b/.claude/skills/edit-contract/SKILL.md
@@ -25,8 +25,8 @@ section claims, restructuring). Not for typo fixes or single-sentence edits.
 - Forbidden: {claims that must NOT appear; scope that must NOT leak in}
 
 ## Scope
-- May change: {files/sections}
-- Must not change: {adjacent sections, quoted spans, other chapters}
+- May change: {chapters/ch3.md}
+- Must not change: {chapters/ch2.md, chapters/ch4.md}
 
 ## Attempts
 - [ ] Attempt 1: {date} — {outcome: accepted / revise / rejected, one line why}
@@ -57,10 +57,22 @@ produce a fourth patch under the old contract.
 1. One contract file per edit goal; append-only Attempts. Append the next
    attempt line as you make it rather than pre-writing empty ones.
 
+   **Scope lines are paths.** `May change:` and `Must not change:` are read by
+   a guard, not by a reader: comma-separated repository paths only, no prose
+   around them. Write `chapters/ch3.md`, not "the opening sentence of
+   chapters/ch3.md". A line the guard cannot read is refused with
+   `CONTRACT_UNPARSABLE` rather than guessed at — reading it as an empty scope
+   would silently ignore a contract you wrote, and reading it as a list would
+   deny every chapter write including the one it exists to allow. If the real
+   constraint is narrower than a file, say so in the spine card, where it is
+   guidance for you, and leave the scope line at the file.
+
    **Retiring a contract.** A contract is active while any `- [ ] Attempt`
-   line is unticked, and an active contract scopes every chapter write. When
-   the goal is done or abandoned, tick its attempts — that retires it. Leaving
-   a finished contract active makes it scope tomorrow's work as well, and two
+   line is unticked, and an active contract scopes every chapter write. Tick an
+   attempt only when the **goal is complete** or abandoned — not after a single
+   edit. Ticking retires the contract, and a retired contract stops constraining
+   anything, including the paths it lists under `Must not change`. Leaving a
+   finished contract active instead makes it scope tomorrow's work, and two
    active contracts at once are refused with `CONTRACT_AMBIGUOUS` naming both,
    because the guard cannot know which one an edit belongs to.
 2. Never edit outside Scope; never touch quoted spans.

--- a/guards/README.md
+++ b/guards/README.md
@@ -17,6 +17,7 @@ pinned harness by the testkit tier and the live e2e.
 | Quoted text in existing chapters is immutable | `ctx.tools.guard` | quotation-delimited spans of the target file before vs after the proposed write/edit | deny `QUOTE_SPAN_MODIFIED` |
 | Chapter writes stay inside the active edit contract's scope | `ctx.tools.guard` | target path against the one on-disk active contract's `May change:` / `Must not change:` lists | deny `CONTRACT_SCOPE` |
 | Exactly one edit contract may be active at a time | `ctx.tools.guard` | contracts under `contracts/` still carrying an unticked `- [ ] Attempt` | deny `CONTRACT_AMBIGUOUS` |
+| A contract whose scope the guard cannot read enforces nothing, so it refuses | `ctx.tools.guard` | each `May change:` / `Must not change:` entry against a path shape | deny `CONTRACT_UNPARSABLE` |
 | ≤ 15 pages per `read_pdf` invocation | `ctx.tools.guard` | `first_page`..`last_page` of the requested call | deny `PAGE_RANGE_EXCEEDED` |
 | ≤ 90 pages per session | `ctx.tools.guard` | successful `read_pdf` results folded from the append-only session log (page-budget projection) | deny `PAGE_BUDGET_EXCEEDED` |
 | After 3 typed-denial attempts under a contract, further in-scope chapter writes need the author | `tools/pre-execute` waterfall | per-contract typed-denial attempts folded from the session log (revision-attempts projection) | `ask` with reason `ESCALATION_REQUIRED`, resolved by dsh-user-approval (`allowed-once` / `rejected` / fail-closed `unavailable`) |
@@ -46,7 +47,12 @@ events. No agent-writable file is ever an authority.
   unticked, so a finished contract keeps scoping work until its attempts are
   ticked. Two active at once are refused by name rather than resolved: the
   guard has no way to know which one an edit belongs to, and choosing by
-  directory order silently decided what the author was allowed to change. Contract lifecycle changes through logged writes are
+  directory order silently decided what the author was allowed to change.
+  Scope lines are comma-separated paths. A line written as prose is refused
+  rather than interpreted: read as an empty scope it would silently ignore a
+  contract the author wrote, and read as a list it would deny every chapter
+  write including the one the contract exists to allow. Both were reachable
+  before — the second is what the Gate A acceptance run produced. Contract lifecycle changes through logged writes are
   legitimate management, not bypass; a contract file placed or edited
   outside dsh still scopes writes but never arms the escalation fold.
 - **Page budget**: counts successful logged `read_pdf` results. It cannot

--- a/guards/src/decisions.ts
+++ b/guards/src/decisions.ts
@@ -35,7 +35,13 @@ export interface RepoView {
    * choice about what the author may edit, and the guard cannot know which
    * one they meant.
    */
-  activeContracts(): Array<{ path?: string; mayChange: string[]; mustNotChange: string[] }>
+  activeContracts(): Array<{
+    path?: string
+    mayChange: string[]
+    mustNotChange: string[]
+    /** Scope lines written as prose, which the guard cannot act on. */
+    unreadableScope?: string[]
+  }>
   /** Project-relative paths of every chapter file (chapters/**.md) — corpus-wide checks. */
   chapterFiles(): string[]
   /** The workspace bibliography (references.bib at the root, else the first root-level .bib), if any. */
@@ -170,6 +176,16 @@ export function decideContractScope(call: ToolCall, repo: RepoView): Denial | un
   }
   const contract = contracts[0]
   const which = contract.path ? `"${contract.path}"` : 'the active edit contract'
+  // A scope the guard cannot read is neither an empty scope nor a list. Read as
+  // empty it silently ignores a contract the author wrote; read as a list it
+  // denies every chapter write, including the one the contract exists to allow.
+  const unreadable = contract.unreadableScope ?? []
+  if (unreadable.length > 0) {
+    return {
+      code: 'CONTRACT_UNPARSABLE',
+      message: `${which} has a scope line the guard cannot read (${unreadable.join('; ')}). Scope lines are comma-separated paths, not prose.`,
+    }
+  }
   if (underAny(rel, contract.mustNotChange)) {
     return { code: 'CONTRACT_SCOPE', message: `"${rel}" is listed under "Must not change" in ${which}.` }
   }

--- a/guards/src/dsh-plugin.ts
+++ b/guards/src/dsh-plugin.ts
@@ -171,7 +171,7 @@ export function fsRepoView(projectRoot: string): RepoView {
         if (!name.endsWith('.md')) continue
         const parsed = parseContractSource(readFileSync(join(dir, name), 'utf8'))
         if (!parsed.active) continue
-        out.push({ path: `contracts/${name}`, mayChange: parsed.mayChange, mustNotChange: parsed.mustNotChange })
+        out.push({ path: `contracts/${name}`, mayChange: parsed.mayChange, mustNotChange: parsed.mustNotChange, unreadableScope: parsed.unreadableScope })
       }
       return out
     },

--- a/guards/src/projections.ts
+++ b/guards/src/projections.ts
@@ -166,19 +166,45 @@ export interface ContractSource {
   active: boolean
   mayChange: string[]
   mustNotChange: string[]
+  /**
+   * Scope lines that were written as prose rather than as a path list, quoted
+   * as the author wrote them. The guard matches paths, so a line it cannot
+   * read is neither an empty scope nor a list — it is a contract that cannot
+   * be enforced, and saying so is the only honest option.
+   */
+  unreadableScope: string[]
 }
 
 /** Parse one contract file's content (the P1 fsRepoView rules, extracted). */
+/** A scope entry the guard can act on: one path, no prose around it. */
+const PATH_ENTRY = /^[A-Za-z0-9._\-/]+$/
+
+function parseScopeLine(text: string, label: string, problems: string[]): string[] {
+  const line = text.match(new RegExp(`^- ${label}:\\s*(.+)$`, 'm'))?.[1]
+  if (line === undefined) return []
+  const entries = line
+    .split(',')
+    .map((s) => s.trim().replace(/[.;]+$/, ''))
+    .filter((s) => s.length > 0)
+  // An unfilled template placeholder is not a contract the author wrote.
+  const filled = entries.filter((s) => !s.startsWith('{'))
+  if (filled.length === 0) return []
+  if (filled.some((s) => !PATH_ENTRY.test(s))) {
+    problems.push(`${label}: ${line.trim()}`)
+    return []
+  }
+  return filled
+}
+
 export function parseContractSource(text: string): ContractSource {
-  const scope = (label: string) =>
-    (text.match(new RegExp(`^- ${label}:\\s*(.+)$`, 'm'))?.[1] ?? '')
-      .split(',')
-      .map((s) => s.trim())
-      .filter((s) => s.length > 0 && !s.startsWith('{'))
+  const problems: string[] = []
+  const mayChange = parseScopeLine(text, 'May change', problems)
+  const mustNotChange = parseScopeLine(text, 'Must not change', problems)
   return {
     active: /^- \[ \] Attempt/m.test(text),
-    mayChange: scope('May change'),
-    mustNotChange: scope('Must not change'),
+    mayChange,
+    mustNotChange,
+    unreadableScope: problems,
   }
 }
 

--- a/guards/src/vocabulary.ts
+++ b/guards/src/vocabulary.ts
@@ -22,7 +22,7 @@
 // --- denial codes -------------------------------------------------------------
 
 /** Chapter-write guard denial codes (P1 session 1). */
-export const CHAPTER_DENIAL_CODES = ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE', 'CONTRACT_AMBIGUOUS'] as const
+export const CHAPTER_DENIAL_CODES = ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE', 'CONTRACT_AMBIGUOUS', 'CONTRACT_UNPARSABLE'] as const
 export type ChapterDenialCode = (typeof CHAPTER_DENIAL_CODES)[number]
 
 /** read_pdf page-budget denial codes (P1 session 2). */

--- a/guards/tests/contract-lifecycle.test.ts
+++ b/guards/tests/contract-lifecycle.test.ts
@@ -17,7 +17,7 @@
 
 import { test } from 'node:test'
 import assert from 'node:assert/strict'
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -110,4 +110,97 @@ test('the shipped contract template does not leave a finished contract active', 
   assert.equal(parseContractSource(template.replace('- [ ]', '- [x]')).active, false,
     'ticking the attempt must retire the contract')
   assert.match(skill, /retire|retiring/i, 'the skill must say how a contract is retired')
+})
+
+// --- scope lines the guard cannot read ---------------------------------------
+// Found by the Gate A §7 acceptance run, not by any unit test: the skill's
+// template invites prose in `- May change:` and the parser split on commas and
+// matched literally, so a real contract produced
+//   mayChange: ["the first prose sentence of chapters/ch1.md only (clarity"]
+// which can never match a path. The unit tests all supplied well-formed path
+// lists, which is exactly why they could not see it.
+//
+// Either extreme is wrong here. Treating an unreadable line as "no scope" lets
+// a contract the author wrote be silently ignored; treating it as a non-empty
+// list denies every chapter write including the one it was meant to allow.
+// A scope the guard cannot read is a refusal that says so.
+
+test('a scope line written as prose is refused, not silently matched against', () => {
+  const d = decideContractScope(
+    { tool: 'write', args: { file_path: 'chapters/ch1.md', content: 'x' } },
+    repo({ activeContracts: () => [{
+      path: 'contracts/prose.md',
+      mayChange: ['the first prose sentence of chapters/ch1.md only (clarity'],
+      mustNotChange: [],
+      unreadableScope: ['May change: the first prose sentence of chapters/ch1.md only (clarity rewrite)'],
+    }] }),
+  )
+  assert.equal(d?.code, 'CONTRACT_UNPARSABLE')
+  assert.match(d!.message, /contracts\/prose\.md/)
+  assert.match(d!.message, /May change/)
+})
+
+test('an unreadable scope does not become a licence to write anywhere', () => {
+  // The failure this replaces: the contract named chapters/ch2.md under
+  // "Must not change" and ch2 was written minutes later.
+  const d = decideContractScope(
+    { tool: 'write', args: { file_path: 'chapters/ch2.md', content: 'x' } },
+    repo({ activeContracts: () => [{
+      path: 'contracts/prose.md', mayChange: [], mustNotChange: [],
+      unreadableScope: ['Must not change: the rest of chapters/ch1.md, quoted spans, and chapters/ch2.md'],
+    }] }),
+  )
+  assert.equal(d?.code, 'CONTRACT_UNPARSABLE')
+})
+
+test('a clean path list is read as before', async () => {
+  const { parseContractSource } = await import(
+    pathToFileURL(join(PRODUCT_ROOT, 'guards', 'dist', 'projections.js')).href
+  )
+  const parsed = parseContractSource([
+    '## Scope',
+    '- May change: chapters/ch1.md, chapters/ch2.md',
+    '- Must not change: chapters/ch3.md',
+    '',
+    '## Attempts',
+    '- [ ] Attempt 1: pending',
+  ].join('\n'))
+  assert.deepEqual(parsed.mayChange, ['chapters/ch1.md', 'chapters/ch2.md'])
+  assert.deepEqual(parsed.mustNotChange, ['chapters/ch3.md'])
+  assert.deepEqual(parsed.unreadableScope, [])
+})
+
+test('the parser reports the prose it could not read rather than dropping it', async () => {
+  const { parseContractSource } = await import(
+    pathToFileURL(join(PRODUCT_ROOT, 'guards', 'dist', 'projections.js')).href
+  )
+  const parsed = parseContractSource([
+    '## Scope',
+    '- May change: the first prose sentence of chapters/ch1.md only (clarity rewrite)',
+    '- Must not change: chapters/ch2.md',
+  ].join('\n'))
+  assert.equal(parsed.unreadableScope.length, 1)
+  assert.match(parsed.unreadableScope[0], /May change/)
+  // The readable line is still read; one bad line does not poison the other.
+  assert.deepEqual(parsed.mustNotChange, ['chapters/ch2.md'])
+})
+
+test('the template placeholder is not treated as prose the author wrote', async () => {
+  const { parseContractSource } = await import(
+    pathToFileURL(join(PRODUCT_ROOT, 'guards', 'dist', 'projections.js')).href
+  )
+  const parsed = parseContractSource('- May change: {files you may touch}\n- Must not change: {everything else}')
+  assert.deepEqual(parsed.unreadableScope, [], 'an unfilled template must not read as a broken contract')
+})
+
+test('the skill tells the author that scope lines are paths, and what ticking an attempt does', () => {
+  const skill = readFileSync(join(PRODUCT_ROOT, '.claude', 'skills', 'edit-contract', 'SKILL.md'), 'utf8')
+  const template = /```markdown\n([\s\S]*?)```/.exec(skill)?.[1] ?? ''
+  const mayChange = /^- May change:\s*(.+)$/m.exec(template)?.[1] ?? ''
+  assert.doesNotMatch(mayChange, /sentence|section|paragraph/i,
+    'the template invites prose where the guard reads paths')
+  assert.match(skill, /comma-separated|path list|paths only/i,
+    'the skill must say the scope lines are paths')
+  assert.match(skill, /goal is (complete|done)|not after a single|only when the goal/i,
+    'the skill must say an attempt is ticked when the goal is done, not after one edit')
 })

--- a/guards/tests/projections.test.ts
+++ b/guards/tests/projections.test.ts
@@ -306,7 +306,7 @@ test('relativeToRoot handles absolute, relative, and out-of-root paths', () => {
 
 test('parseContractSource and parseNotesSource are the single parse authority', () => {
   const parsed = parseContractSource(CONTRACT_BODY)
-  assert.deepEqual(parsed, { active: true, mayChange: ['chapters/ch3.md'], mustNotChange: ['chapters/ch2.md'] })
+  assert.deepEqual(parsed, { active: true, mayChange: ['chapters/ch3.md'], mustNotChange: ['chapters/ch2.md'], unreadableScope: [] })
   assert.deepEqual(parseNotesSource(NOTES_BODY), { surname: 'smith', year: '2024' })
   assert.equal(parseNotesSource('no source line here'), undefined)
 })

--- a/guards/tests/vocabulary.test.ts
+++ b/guards/tests/vocabulary.test.ts
@@ -20,11 +20,11 @@ import {
   revisionAttemptsSchema,
 } from '../src/vocabulary.ts'
 
-test('the denial-code catalogue is exactly the seven codes — five from P1, the P4 export gate, and the Gate A contract ambiguity', () => {
-  assert.deepEqual([...CHAPTER_DENIAL_CODES], ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE', 'CONTRACT_AMBIGUOUS'])
+test('the denial-code catalogue is exactly the eight codes — five from P1, the P4 export gate, and the two Gate A contract refusals', () => {
+  assert.deepEqual([...CHAPTER_DENIAL_CODES], ['NOTES_MISSING', 'QUOTE_SPAN_MODIFIED', 'CONTRACT_SCOPE', 'CONTRACT_AMBIGUOUS', 'CONTRACT_UNPARSABLE'])
   assert.deepEqual([...PAGE_DENIAL_CODES], ['PAGE_RANGE_EXCEEDED', 'PAGE_BUDGET_EXCEEDED'])
   assert.deepEqual([...EXPORT_DENIAL_CODES], ['EXPORT_SOURCES_UNRESOLVED'])
-  assert.equal(ALL_DENIAL_CODES.length, 7)
+  assert.equal(ALL_DENIAL_CODES.length, 8)
   // ESCALATION_REQUIRED must NOT be claimed until the session-2 ask seam ships.
   assert.ok(!(ALL_DENIAL_CODES as readonly string[]).includes('ESCALATION_REQUIRED'))
 })


### PR DESCRIPTION
Fixes the two findings from the Gate A §7 acceptance run. Found by that run, not by any test.

## The template invited prose where the guard reads paths

A real contract, written by the model during the acceptance loop, produced:

```
mayChange: ["the first prose sentence of chapters/ch1.md only (clarity"]
```

That can never match a path. **Every unit test supplied well-formed path lists**, which is exactly why none of them could see it — the fixtures were not shaped like what the product actually produces.

## Either reading was wrong

| read as | consequence |
| --- | --- |
| an empty scope | silently ignores a contract the author wrote |
| a non-empty list | denies **every** chapter write, including the one the contract exists to allow |

The second is what the run was one step from. The contract retired itself before the next write, so the prohibition on `chapters/ch2.md` never applied and ch2 was created — the failure the acceptance record reports.

`parseContractSource` now accepts only path-shaped entries and reports the lines it could not read; `decideContractScope` refuses with `CONTRACT_UNPARSABLE` naming the contract and the line. An unfilled template placeholder is still not a broken contract.

Checked against the contract the acceptance run actually produced: two unreadable lines, and the refusal names both.

## The template and the skill

The template writes paths instead of inviting prose, and the skill says the lines are read by a guard rather than by a reader. Where the real constraint is narrower than a file, the spine card is the place for it.

## On ticking an attempt

The run showed a model tick its box on finishing one edit, which retires the contract — **correct under the item 5 rule, and surprising**, because "Must not change" then stops applying.

That is an instruction problem rather than a code one, and it is treated as such: the skill now says an attempt is ticked when the *goal* is complete, not after a single edit, and that a retired contract constrains nothing. No behaviour was changed to paper over it.

## Gates

Vocabulary seven codes to eight; the canonical pin is updated, not duplicated.

```
guards 157/157 · make test 132/132 · e2e · credential · skill-scope · e1 offline
```

The acceptance run's other two findings are documentation gaps in the quickstart (`npm ci --prefix e2e`, `make setup`) and are not in this PR.