### PR TITLE
The quickstart names every step it needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ converter rather than guessing), and one
 provider key at run time.
 
 ```bash
+make setup                                   # configs + the /export conversion backend
 npm ci --prefix guards && npm run build --prefix guards
+npm ci --prefix e2e                          # `awt verify` runs the live denial table from here
 node scaffold/awt.mjs init ~/thesis          # clean workspace + skill links
 node scaffold/awt.mjs install-profile        # profiles into ~/.dsh + the pinned harness
+node scaffold/awt.mjs verify ~/thesis        # six stages, keyless, scratch-only
 export DEEPSEEK_API_KEY=...                  # or ANTHROPIC_API_KEY
 node scaffold/awt.mjs run ~/thesis "task"    # one headless task
 

--- a/docs/e2-dogfood-runbook.md
+++ b/docs/e2-dogfood-runbook.md
@@ -14,6 +14,7 @@ It is not a substitute for this author-operated cycle.
 
 ```bash
 # from the toolkit checkout
+make setup                       # configs + the /export conversion backend
 cd guards && npm install && npm run build && cd ..
 cd e2e && npm ci && cd ..
 


### PR DESCRIPTION
The last two findings from the Gate A §7 acceptance runs.

Both runs stopped twice before `awt verify` passed, on steps the README does not mention:

| missing | why verify needs it |
| --- | --- |
| `npm ci --prefix e2e` | the live denial table runs from there |
| `make setup` | verify's sixth stage asks the converter for a backend |

Each error was typed and each remedy worked, so a reader recovers. But they recover from a documented path that was incomplete, and not making them do that is the first thing a quickstart is for.

`awt verify` also moves into the sequence rather than being mentioned after it, so the reader confirms the install where the confirmation belongs.

## Verified the way the gap was found

Fresh clone, copy the block, run it in order:

```
make setup = 0 · guards = 0 · e2e = 0 · init = 0 · install-profile = 0
verify = 0 → VERIFY PASSED (6/6)
```

First try, no detours.

```
guards 157/157 · make test 132/132 · e2e · credential · skill-scope
```

With this, §7 is met on macOS. The Windows repeat is the only criterion left, and it is tracked separately.