### PR TITLE
readme: name the release candidate and what makes it one

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # Academic Writing Toolkit
 
 [![CI](https://github.com/yha9806/academic-writing-toolkit/actions/workflows/test.yml/badge.svg)](https://github.com/yha9806/academic-writing-toolkit/actions/workflows/test.yml)
-[![Latest release](https://img.shields.io/github/v/release/yha9806/academic-writing-toolkit?display_name=tag&sort=semver)](https://github.com/yha9806/academic-writing-toolkit/releases/latest)
+[![Latest release](https://img.shields.io/github/v/release/yha9806/academic-writing-toolkit?display_name=tag&sort=semver&include_prereleases)](https://github.com/yha9806/academic-writing-toolkit/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-15967D.svg)](LICENSE)
 [![Agent Skills](https://img.shields.io/badge/Agent_Skills-compatible-6F88F7.svg)](https://agentskills.io)
 
@@ -13,18 +13,30 @@ Academic Writing Toolkit (AWT) is an open-source, local-first system for evidenc
 
 The core promise is simple: **agents may help operate the workflow; the author keeps control of claims, boundaries, approvals, and the exact artifact that ships.**
 
-> **Current stable release: [v0.5.0](https://github.com/yha9806/academic-writing-toolkit/releases/tag/v0.5.0)** —
-> the last release carrying the Workbench wheel, Codex plugin package, and
-> ChatGPT App. `main` is the v0.1 rebuild: AWT as a
+> **Latest: [v0.6.0-rc.1](https://github.com/yha9806/academic-writing-toolkit/releases/tag/v0.6.0-rc.1), a pre-release.**
+> It is the first tag of the v0.1 rebuild: AWT as a
 > [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness)
 > distribution — a 9-skill catalogue plus deterministic guard plugins with
 > typed denials, session-log-derived governance, and harness-event approvals.
-> Evidence status is stated per §11 of the
-> [v0.1 design](docs/specs/2026-08-16-awt-dsh-app-v0.1-design.md): every
-> enforcement claim is CI-proven (E0). A [three-source local E1 pilot](e1/published/2026-09-05-local-qwen/README.md)
-> is now recorded; neither arm produced lint-conforming notes, so it does
-> not demonstrate improved writing efficacy. Author-dogfood and external
-> evidence remain pending.
+> ("v0.1" there is the architecture generation, not the version number;
+> `v0.1.0` was taken in May 2026, so the release line continues from v0.5.0.)
+>
+> It is a release candidate because of what has and has not been verified.
+> Every enforcement claim is CI-proven (E0), and the daily loop has been run
+> end to end against the acceptance criteria in
+> [Gate A §7](docs/specs/2026-09-06-gate-a-workspace-contract.md) — **on macOS
+> only**; the Windows repeat is open as
+> [#56](https://github.com/yha9806/academic-writing-toolkit/issues/56). A
+> [three-source local E1 pilot](e1/published/2026-09-05-local-qwen/README.md)
+> is recorded and negative: neither arm produced lint-conforming notes, so it
+> does not demonstrate improved writing efficacy. Author-dogfood (E2) and
+> external evidence (E3) remain pending. Evidence classes are stated per §11
+> of the [v0.1 design](docs/specs/2026-08-16-awt-dsh-app-v0.1-design.md).
+>
+> **[v0.5.0](https://github.com/yha9806/academic-writing-toolkit/releases/tag/v0.5.0)
+> is the last release of the previous product** — the Workbench wheel, Codex
+> plugin package and ChatGPT App, all decommissioned since. It is still the
+> place to get those, and nothing on `main` replaces them.
 
 AWT is not a hosted writing service and does not operate a manuscript-storage
 backend. Its deterministic tools stay local. Provider routes are configured by
@@ -314,6 +326,9 @@ Edit `CLAUDE.md` for project-specific directories, page limits, British English 
 
 ## Release and distribution
 
+- [v0.6.0-rc.1](https://github.com/yha9806/academic-writing-toolkit/releases/tag/v0.6.0-rc.1)
+  — pre-release, the first tag of the dsh-distribution architecture; verified
+  against Gate A §7 on macOS and not yet on Windows (#56)
 - [v0.5.0 stable release](https://github.com/yha9806/academic-writing-toolkit/releases/tag/v0.5.0)
   — the last release carrying the ChatGPT App, its privacy/terms documents,
   the Cloud Run/Render deployments, and the local workbench wheel; those


### PR DESCRIPTION
The README opened with "Current stable release: v0.5.0" and described `main` as
the untagged rebuild. Both were true until `v0.6.0-rc.1` was cut, and neither
is now: a reader arriving at Releases sees the rc at the top with nothing in
the README to tell them what it is.

## What changed

**The callout leads with the rc, and says why it is a candidate.** Every
enforcement claim is CI-proven (E0); the daily loop passes the Gate A §7
acceptance criteria **on macOS only**, with the Windows repeat open as #56; the
E1 pilot is recorded and negative; E2 and E3 do not exist. That is the same
evidence statement the README already carried, attached to a tag instead of to
a branch.

**v0.5.0 is restated as the last release of the previous product** rather than
as the current stable one. It is still where the Workbench wheel, Codex plugin
and ChatGPT App come from, and nothing on `main` replaces them — that sentence
is worth keeping visible.

**The release badge was pointing at the wrong product.** `sort=semver` without
`include_prereleases` resolves to v0.5.0, so the words "Latest release" linked
a reader to the decommissioned surfaces. It now includes prereleases and links
to the releases list, where GitHub labels each entry itself.

**The numbering is recorded**, because I got it wrong once and pushed
`v0.1.0-rc.1`: "v0.1" in the design document is the architecture generation,
and `v0.1.0` was taken in May 2026 by the packaged Codex plugin.

## Verified

macOS, this branch, before opening:

- `make test` — 132/132, exit 0
- `npm test --prefix guards` — 157/157, exit 0

Not a no-op run for a documentation change: `scripts/test.sh` greps README for
all nine skill names and for two retired terms, so a callout rewrite is inside
what the suite covers.

No red-first test here — this is prose correcting itself against a tag that now
exists, not a fix to behaviour. Nothing in the diff is an enforcement claim.

Part of Gate C. Does not close #56, which is what the rc is a candidate on.
